### PR TITLE
NUE-85: json diff view in experiments

### DIFF
--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -67,6 +67,7 @@ export default function ExperimentRefSummary({
 }) {
   const { variations } = rule;
   const type = feature.valueType;
+  const featureDefault = feature.defaultValue;
 
   const { namespaces } = useOrgSettings();
 
@@ -261,7 +262,11 @@ export default function ExperimentRefSummary({
                       {j}.
                     </td>
                     <td>
-                      <ValueDisplay value={value} type={type} />
+                      <ValueDisplay
+                        value={value}
+                        type={type}
+                        defaultVal={featureDefault}
+                      />
                       <ValidateValue value={value} feature={feature} />
                     </td>
                     <td>{variation.name}</td>

--- a/packages/front-end/components/Features/JsonDiff.tsx
+++ b/packages/front-end/components/Features/JsonDiff.tsx
@@ -1,0 +1,21 @@
+import CSSProperties from "react";
+import ReactJsonViewCompare from "react-json-view-compare";
+
+export default function JsonDiff({
+  value,
+  defaultVal,
+  fullStyle = { maxHeight: 250, overflowY: "auto", maxWidth: "100%" },
+}: {
+  value: string;
+  defaultVal: string;
+  fullStyle?: CSSProperties;
+}) {
+  return (
+    <div style={fullStyle}>
+      <ReactJsonViewCompare
+        oldData={JSON.parse(defaultVal)}
+        newData={JSON.parse(value)}
+      />
+    </div>
+  );
+}

--- a/packages/front-end/components/Features/JsonDiff.tsx
+++ b/packages/front-end/components/Features/JsonDiff.tsx
@@ -1,13 +1,13 @@
-import CSSProperties from "react";
+import { CSSProperties } from "react";
 import ReactJsonViewCompare from "react-json-view-compare";
 
 export default function JsonDiff({
   value,
-  defaultVal,
+  defaultVal = "{}",
   fullStyle = { maxHeight: 250, overflowY: "auto", maxWidth: "100%" },
 }: {
   value: string;
-  defaultVal: string;
+  defaultVal?: string;
   fullStyle?: CSSProperties;
 }) {
   return (

--- a/packages/front-end/components/Features/ValueDisplay.tsx
+++ b/packages/front-end/components/Features/ValueDisplay.tsx
@@ -1,6 +1,7 @@
 import { FeatureValueType } from "back-end/types/feature";
 import { CSSProperties, useMemo } from "react";
 import stringify from "json-stringify-pretty-compact";
+import dynamic from "next/dynamic";
 import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
 
 export default function ValueDisplay({
@@ -9,12 +10,14 @@ export default function ValueDisplay({
   full = true,
   additionalStyle = {},
   fullStyle = { maxHeight: 150, overflowY: "auto", maxWidth: "100%" },
+  defaultVal = "",
 }: {
   value: string;
   type: FeatureValueType;
   full?: boolean;
   additionalStyle?: CSSProperties;
   fullStyle?: CSSProperties;
+  defaultVal?: string;
 }) {
   const formatted = useMemo(() => {
     if (type === "boolean") return value;
@@ -61,6 +64,15 @@ export default function ValueDisplay({
         {formatted}
       </div>
     );
+  }
+
+  if (type === "json" && defaultVal != "") {
+    // the json diff code needs a window to attach to, so must be loaded dynamically
+    const JsonDiff = dynamic(() => import("../Features/JsonDiff"), {
+      ssr: false,
+    });
+
+    return <JsonDiff value={value} defaultVal={defaultVal} />;
   }
 
   return (

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -67,6 +67,7 @@
     "react-dropzone": "^11.3.2",
     "react-hook-form": "^7.34.0",
     "react-icons": "^5.2.1",
+    "react-json-view-compare": "^2.0.2",
     "react-markdown": "^9.0.0",
     "react-paginate": "^8.0.0",
     "react-player": "^2.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17917,6 +17917,18 @@ react-is@^18.1.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-json-view-compare@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-json-view-compare/-/react-json-view-compare-2.0.2.tgz#7a947caae1a0e133b22e0e327e1ad44cf3929dec"
+  integrity sha512-we+OMLFR2FGqHeoqfubQnMhY5V4jLK15/cOnh7cj+v6v7XpizdJu4oSfbEwRWxvTzywSTqpBw/xL0kPZ2YkLIg==
+  dependencies:
+    react-json-viewer-cool "^2.0.0"
+
+react-json-viewer-cool@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-json-viewer-cool/-/react-json-viewer-cool-2.0.0.tgz#dbce44305899b083f76120eaa14e9f9c96a140b8"
+  integrity sha512-2bCC9szMbh9PEK5WmAv2253MwjWdK/58RCleqIqvtVjoFFCtWRPXKbe+uK6cxxGRrtCPFLJE+4H1+T+pUQltLQ==
+
 react-markdown@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/react-markdown/-/react-markdown-9.0.0.tgz"


### PR DESCRIPTION
### Features and Changes
Adds json diff view to treatments in Feature pages, so that it is easier for folks to figure out the real changes present even in very big features with many lines of json.

I have very little frontend / web dev experience, so in the interest of getting something working quickly I shopped around a bit for a plug-and-play solution for this. https://github.com/praneshr/react-diff-viewer seems like the most comprehensive available option, with a bunch of modularity and stuff. However, it is missing what I view as a critical feature which is true json diffing that actually treats the json as a nested object rather than just a blob of text. Among other issues, this means that it would treat these two as different when in truth they are functionally identical:
```
{
  "key1": "val1",
  "key2": "val2"
}
{
  "key2": "val2",
  "key1": "val1"
}
```
And it also has difficulty figuring out changes in more deeply nested stuff, but this is harder to give a clean example of.

Because I view this feature as necessary, I have opted to use https://github.com/5SSS/react-json-view-compare instead, which is a much worse library in terms of modularity (e.g. there isn't a toggle to dark mode), but which critically does do the proper json diffing.

https://citizenteam.atlassian.net/browse/NUE-85

### Dependencies
This adds a dependency to `react-json-diff-viewer`.

### Testing
Run the server locally and navigate to Features, then view a feature with experiments set up.

### Screenshots
Old
<img width="1497" alt="Screenshot 2024-08-27 at 11 02 43 AM" src="https://github.com/user-attachments/assets/bf561f68-2c8e-4b69-837d-2143acc6bd91">
New
<img width="1497" alt="Screenshot 2024-08-27 at 10 59 24 AM" src="https://github.com/user-attachments/assets/f3ac61d9-c60a-47f9-b7bc-7158c9696df7">
