### PR TITLE
NUE-94: make comments on versions mandatory

### DIFF
--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -168,7 +168,7 @@ export default function DraftModal({
           : undefined
       }
       cta="Publish"
-      ctaEnabled={!!mergeResult.success && hasChanges}
+      ctaEnabled={!!mergeResult.success && hasChanges && comment != ""}
       close={close}
       closeCta="Cancel"
       size="max"
@@ -226,7 +226,7 @@ export default function DraftModal({
           </div>
           {hasPermission ? (
             <Field
-              label="Add a Comment (optional)"
+              label="Add a Comment (required)"
               textarea
               placeholder="Summary of changes..."
               value={comment}

--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -168,7 +168,7 @@ export default function DraftModal({
           : undefined
       }
       cta="Publish"
-      ctaEnabled={!!mergeResult.success && hasChanges && comment != ""}
+      ctaEnabled={!!mergeResult.success && hasChanges && !!comment?.trim()}
       close={close}
       closeCta="Cancel"
       size="max"

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -88,7 +88,7 @@ export default function RevertModal({
           : undefined
       }
       cta="Revert and Publish"
-      ctaEnabled={comment != ""}
+      ctaEnabled={!!comment?.trim()}
       close={close}
       closeCta="Cancel"
       size="max"

--- a/packages/front-end/components/Features/RevertModal.tsx
+++ b/packages/front-end/components/Features/RevertModal.tsx
@@ -88,6 +88,7 @@ export default function RevertModal({
           : undefined
       }
       cta="Revert and Publish"
+      ctaEnabled={comment != ""}
       close={close}
       closeCta="Cancel"
       size="max"
@@ -107,7 +108,7 @@ export default function RevertModal({
       </div>
       {hasPermission && (
         <Field
-          label="Add a Comment (optional)"
+          label="Add a Comment (required)"
           textarea
           value={comment}
           onChange={(e) => {


### PR DESCRIPTION
### Features and Changes
https://citizenteam.atlassian.net/browse/NUE-94
Makes commenting mandatory when creating a new version of a feature, or reverting a previous feature change.

### Dependencies
None

### Testing
Running locally, attempt to publish a new version of a feature without a comment. The Publish button is grayed out until a comment is added.

### Screenshots
New
<img width="1535" alt="Screenshot 2024-08-28 at 11 42 35 AM" src="https://github.com/user-attachments/assets/1ee802b3-4aed-4715-8ad4-2a4b8f89e1b4">
Old
<img width="1535" alt="Screenshot 2024-08-28 at 11 42 54 AM" src="https://github.com/user-attachments/assets/a4b75369-09e2-47e0-a754-6500f2fa48bd">
