### PR TITLE
NUE-97: better json editor

### DIFF
--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -11,6 +11,7 @@ import stringify from "json-stringify-pretty-compact";
 import { BsBoxArrowUpRight } from "react-icons/bs";
 import dJSON from "dirty-json";
 import clsx from "clsx";
+import { JsonEditor as Editor } from "json-edit-react";
 import Field from "@/components/Forms/Field";
 import Toggle from "@/components/Forms/Toggle";
 import { useUser } from "@/services/UserContext";
@@ -19,6 +20,8 @@ import MultiSelectField from "@/components/Forms/MultiSelectField";
 import Modal from "@/components/Modal";
 import { GBAddCircle } from "@/components/Icons";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import { useAppearanceUITheme } from "@/services/AppearanceUIThemeProvider";
+import Button from "@/components/Button";
 
 export interface Props {
   valueType: FeatureValueType;
@@ -470,67 +473,114 @@ function JSONTextEditor({
   helpText?: ReactNode;
   placeholder?: string;
 }) {
+  const { theme } = useAppearanceUITheme();
+  const [useJson, setUseJson] = useState(false);
+  if (useJson) {
+    try {
+      const parsed = JSON.parse(value);
+      const setJson = (json) => {
+        setValue(JSON.stringify(json));
+      };
+
+      const editorTheme = theme === "light" ? "githubLight" : "githubDark";
+      return (
+        <div>
+          <Button
+            onClick={() => {
+              setUseJson(false);
+            }}
+          >
+            Plain Text
+          </Button>
+          <div>
+            <label>{" " + label}</label>
+          </div>
+          <Editor
+            data={parsed}
+            setData={setJson}
+            theme={editorTheme}
+            maxWidth={10000}
+          />
+        </div>
+      );
+    } catch (e) {
+      // Render normally if we can't parse json
+    }
+  }
+
   let formatted;
+  let buttonDisabled = true;
   try {
     const parsed = dJSON.parse(value);
     formatted = stringify(parsed);
+    buttonDisabled = false;
   } catch (e) {
     // Ignore
   }
 
   return (
-    <Field
-      labelClassName={editAsForm ? "d-flex w-100" : ""}
-      placeholder={placeholder}
-      label={
-        editAsForm ? (
-          <>
-            <div>{label}</div>
-            {editAsForm && (
-              <div className="ml-auto">
-                <a
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    editAsForm();
-                  }}
-                >
-                  Edit as Form
-                </a>
-              </div>
-            )}
-          </>
-        ) : (
-          label
-        )
-      }
-      value={value}
-      onChange={(e) => {
-        setValue(e.target.value);
-      }}
-      textarea
-      minRows={1}
-      helpText={
-        <div className="d-flex align-items-top">
-          {helpText && <div>{helpText}</div>}
-          <a
-            href="#"
-            className={clsx("text-purple ml-auto", {
-              "text-muted cursor-default no-underline":
-                !formatted || formatted === value,
-            })}
-            onClick={(e) => {
-              e.preventDefault();
-              if (formatted && formatted !== value) {
-                setValue(formatted);
-              }
-            }}
-          >
-            <FaMagic /> Format JSON
-          </a>
-        </div>
-      }
-    />
+    <div>
+      <Button
+        onClick={() => {
+          setUseJson(true);
+        }}
+        disabled={buttonDisabled}
+      >
+        Json Editor
+      </Button>
+      <Field
+        labelClassName={editAsForm ? "d-flex w-100" : ""}
+        placeholder={placeholder}
+        label={
+          editAsForm ? (
+            <>
+              <div>{label}</div>
+              {editAsForm && (
+                <div className="ml-auto">
+                  <a
+                    href="#"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      editAsForm();
+                    }}
+                  >
+                    Edit as Form
+                  </a>
+                </div>
+              )}
+            </>
+          ) : (
+            label
+          )
+        }
+        value={value}
+        onChange={(e) => {
+          setValue(e.target.value);
+        }}
+        textarea
+        minRows={1}
+        helpText={
+          <div className="d-flex align-items-top">
+            {helpText && <div>{helpText}</div>}
+            <a
+              href="#"
+              className={clsx("text-purple ml-auto", {
+                "text-muted cursor-default no-underline":
+                  !formatted || formatted === value,
+              })}
+              onClick={(e) => {
+                e.preventDefault();
+                if (formatted && formatted !== value) {
+                  setValue(formatted);
+                }
+              }}
+            >
+              <FaMagic /> Format JSON
+            </a>
+          </div>
+        }
+      />
+    </div>
   );
 }
 

--- a/packages/front-end/components/Features/FeatureValueField.tsx
+++ b/packages/front-end/components/Features/FeatureValueField.tsx
@@ -493,7 +493,7 @@ function JSONTextEditor({
             Plain Text
           </Button>
           <div>
-            <label>{" " + label}</label>
+            <label>{label}</label>
           </div>
           <Editor
             data={parsed}

--- a/packages/front-end/package.json
+++ b/packages/front-end/package.json
@@ -50,6 +50,7 @@
     "handlebars": "^4.7.8",
     "js-confetti": "^0.11.0",
     "js-yaml": "^4.1.0",
+    "json-edit-react": "^1.15.9",
     "json-stringify-pretty-compact": "^3.0.0",
     "json2csv": "^5.0.7",
     "lodash": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14711,6 +14711,14 @@ json-bignum@^0.0.3:
   resolved "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz"
   integrity sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==
 
+json-edit-react@^1.15.9:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/json-edit-react/-/json-edit-react-1.15.9.tgz#7f124aea25b6ebcdd6f39ae70f1339b4db9dba00"
+  integrity sha512-0ujasLgq/sfPnHeE3Qm/4RNjI/NR0HvxhipO+zmemhjgs1CvGYKB5isqxy2nnsMTH6xRaqfrDbM8KbGI8LF3Kg==
+  dependencies:
+    object-property-assigner "^1.3.0"
+    object-property-extractor "^1.0.11"
+
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz"
@@ -16581,6 +16589,16 @@ object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object-property-assigner@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/object-property-assigner/-/object-property-assigner-1.3.1.tgz#3f6be71be5fcfdaf2053bd11c08e745a57d38809"
+  integrity sha512-3R6x1l1sQA4jQBOqxkxH3DHw0PMh7K5UY4x1Yc5QYbbkzZpAJ8l9w+Trq/64ZRe2thiOsa8JpB4M7D61hnkjRA==
+
+object-property-extractor@^1.0.11:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-property-extractor/-/object-property-extractor-1.0.12.tgz#d3824be4a01e8d4489d3cdcbd1dfc45828d1ad97"
+  integrity sha512-X6rMK1O6O3EU4O06BtATezWKr+5idX6Yo0PndVqr8NlED3Eoa2YE+VKQgQL4EK0+vh+YA83Sjj9Nsi/PuXXeDQ==
 
 object-treeify@^1.1.33:
   version "1.1.33"


### PR DESCRIPTION
### Features and Changes
https://citizenteam.atlassian.net/browse/NUE-97

The existing JSON editor is plaintext, which sucks, especially for big files. This PR adds a toggleable native JSON editor which should be a lot easier to use.

### Dependencies
Adds dependency to json-edit-react

### Testing
Run locally and create a new feature, or edit an existing default value, or edit experiment cohort values. Only applies to JSON data type.

### Screenshots
New (default plaintext view)
<img width="1181" alt="Screenshot 2024-08-29 at 5 07 53 PM" src="https://github.com/user-attachments/assets/437b5b00-a1af-446d-ae94-344e0cb19ca7">
New (json editor view)
<img width="1181" alt="Screenshot 2024-08-29 at 5 09 02 PM" src="https://github.com/user-attachments/assets/ecb4729b-f2d7-4909-ac6a-b1d7c289c55a">
New (showcasing different granularity)
<img width="1181" alt="Screenshot 2024-08-29 at 5 12 21 PM" src="https://github.com/user-attachments/assets/9d7f6fc8-3a07-4468-a470-dbf730bc37f9">
