### PR TITLE
MT-4556: JSON diff improvements

### DIFF
--- a/packages/front-end/components/Features/DraftModal.tsx
+++ b/packages/front-end/components/Features/DraftModal.tsx
@@ -1,4 +1,5 @@
 import { FeatureInterface } from "back-end/types/feature";
+import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
 import { useState, useMemo } from "react";
 import { FaAngleDown, FaAngleRight } from "react-icons/fa";
 import { FeatureRevisionInterface } from "back-end/types/feature-revision";
@@ -7,13 +8,13 @@ import {
   filterEnvironmentsByFeature,
   mergeResultHasChanges,
 } from "shared/util";
-import dynamic from "next/dynamic";
 import { getAffectedRevisionEnvs, useEnvironments } from "@/services/features";
 import { useAuth } from "@/services/auth";
 import Modal from "@/components/Modal";
 import Button from "@/components/Button";
 import Field from "@/components/Forms/Field";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { toDiffableJSON } from "@/services/json";
 
 export interface Props {
   feature: FeatureInterface;
@@ -38,10 +39,6 @@ export function ExpandableDiff({
 
   if (a === b) return null;
 
-  const JsonDiff = dynamic(() => import("../Features/JsonDiff"), {
-    ssr: false,
-  });
-
   return (
     <div className="diff-wrapper">
       <div
@@ -59,7 +56,11 @@ export function ExpandableDiff({
       </div>
       {open && (
         <div className="list-group-item list-group-item-light">
-          <JsonDiff defaultVal={a} value={b} />
+          <ReactDiffViewer
+            oldValue={toDiffableJSON(a)}
+            newValue={toDiffableJSON(b)}
+            compareMethod={DiffMethod.WORDS}
+          />
         </div>
       )}
     </div>

--- a/packages/front-end/components/Features/JsonDiff.tsx
+++ b/packages/front-end/components/Features/JsonDiff.tsx
@@ -1,26 +1,6 @@
 import React, { CSSProperties, useEffect, useRef } from "react";
 import ReactJsonViewCompare from "react-json-view-compare";
 
-function fixJsonRecursive(obj) {
-  if (typeof obj != "string" && typeof obj != "object") {
-    return obj;
-  }
-  if (typeof obj == "string") {
-    let jsonObj;
-    try {
-      jsonObj = JSON.parse(obj);
-    } catch (e) {
-      return obj;
-    }
-    obj = jsonObj;
-  }
-
-  for (const key in obj) {
-    obj[key] = fixJsonRecursive(obj[key]);
-  }
-  return obj;
-}
-
 export default function JsonDiff({
   value,
   defaultVal = "{}",
@@ -30,10 +10,8 @@ export default function JsonDiff({
   defaultVal?: string;
   fullStyle?: CSSProperties;
 }) {
-  let oldData = JSON.parse(defaultVal);
-  oldData = fixJsonRecursive(oldData);
-  let newData = JSON.parse(value);
-  newData = fixJsonRecursive(newData);
+  const oldData = JSON.parse(defaultVal);
+  const newData = JSON.parse(value);
 
   const viewerRef = useRef<HTMLDivElement>(null);
 

--- a/packages/front-end/components/Features/ValueDisplay.tsx
+++ b/packages/front-end/components/Features/ValueDisplay.tsx
@@ -3,6 +3,7 @@ import { CSSProperties, useMemo } from "react";
 import stringify from "json-stringify-pretty-compact";
 import dynamic from "next/dynamic";
 import InlineCode from "@/components/SyntaxHighlighting/InlineCode";
+import { toDiffableJSON } from "@/services/json";
 
 export default function ValueDisplay({
   value,
@@ -72,7 +73,12 @@ export default function ValueDisplay({
       ssr: false,
     });
 
-    return <JsonDiff value={value} defaultVal={defaultVal} />;
+    return (
+      <JsonDiff
+        value={toDiffableJSON(value)}
+        defaultVal={toDiffableJSON(defaultVal)}
+      />
+    );
   }
 
   return (

--- a/packages/front-end/components/HistoryTable.tsx
+++ b/packages/front-end/components/HistoryTable.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import { BsArrowRepeat } from "react-icons/bs";
 import { FaAngleDown, FaAngleUp } from "react-icons/fa";
 import { ago, datetime } from "shared/dates";
-import dynamic from "next/dynamic";
+import ReactDiffViewer, { DiffMethod } from "react-diff-viewer";
 import { useDefinitions } from "@/services/DefinitionsContext";
+import { toDiffableJSON } from "@/services/json";
 import useApi from "@/hooks/useApi";
 import Button from "./Button";
 import Code from "./SyntaxHighlighting/Code";
@@ -35,23 +36,6 @@ function EventDetails({
     return <Link href={`/report/${json.report}`}>View Report</Link>;
   }
 
-  const JsonDiff = dynamic(() => import("./Features/JsonDiff"), {
-    ssr: false,
-  });
-
-  const nestedJSONReplacer = (key: string, value: unknown): unknown => {
-    if (key === "value" || key === "defaultValue") {
-      let ret = value;
-      try {
-        ret = JSON.parse(value as string);
-      } catch (e) {
-        // not valid json, parse as normal
-      }
-      return ret;
-    }
-    return value;
-  };
-
   // Diff (create, update, delete)
   if (json.pre || json.post) {
     return (
@@ -72,10 +56,10 @@ function EventDetails({
             ))}
           </div>
         )}
-        <JsonDiff
-          defaultVal={JSON.stringify(json.pre, nestedJSONReplacer)}
-          value={JSON.stringify(json.post, nestedJSONReplacer)}
-          fullStyle={{ maxHeight: 400, overflowY: "auto", maxWidth: "100%" }}
+        <ReactDiffViewer
+          oldValue={toDiffableJSON(json.pre || {})}
+          newValue={toDiffableJSON(json.post || {})}
+          compareMethod={DiffMethod.WORDS}
         />
       </div>
     );

--- a/packages/front-end/services/json.tsx
+++ b/packages/front-end/services/json.tsx
@@ -1,0 +1,42 @@
+function recursiveSortExpandJSON(obj: object | string): object | string {
+  if (typeof obj != "string" && typeof obj != "object") {
+    return obj;
+  }
+  if (typeof obj == "string") {
+    let jsonObj: object;
+    try {
+      jsonObj = JSON.parse(obj);
+    } catch (e) {
+      return obj;
+    }
+    obj = jsonObj;
+  }
+
+  if (!obj) {
+    return obj;
+  }
+
+  // special case array to not transform it to an object below
+  if (Array.isArray(obj)) {
+    for (const i in obj) {
+      obj[i] = recursiveSortExpandJSON(obj[i]);
+    }
+    return obj;
+  }
+
+  // return a new objects where the keys were added in deterministic (sorted) order
+  return Object.keys(obj)
+    .sort()
+    .reduce(function (result, key) {
+      result[key] = recursiveSortExpandJSON(obj[key]);
+      return result;
+    }, {});
+}
+
+export function toDiffableJSON(str: string): string {
+  const obj = recursiveSortExpandJSON(str);
+  if (typeof obj != "object") {
+    return obj;
+  }
+  return JSON.stringify(obj, null, 2);
+}


### PR DESCRIPTION
The diff in draft modal can be confusing when the only change done from previous version is moving of one rule. The original (from forked repo) diff view works good enough for the move operation, so reverted to that in "draft modal" and "audit log (HistoryTable)". Kept the json diff view in values view (that compares individual rule values to the default value).

The text based diff view has issues when some keys are in different order, which often happens. To reduce such diff, all objects keys are sorted before diffing (previously `fixJsonRecursive`, now `recursiveSortExpandJSON`, modified to also sort, and extracted to be usable outside of JsonDiff component to be usable by the other diff view `ReactDiffViewer`).

The values view (values of individual rules, compared to default value) are kept mostly intact - the JsonDiff component is kept there, the sorting can cause a small change in displayed diff there.

# Screenshots
same operation done on the feature with 1 experiment rule and 1 force rule - changing the order of rules (moving), and small change in experiment json. in "previously" the jsons on same list positions are compared, resulting in confusing diff. in "new", which is the default text based diff, the removal and addition better demonstrates the "move" operation.
## previously
draft modal
![image](https://github.com/user-attachments/assets/b167dc16-021e-4e39-aec3-86ac28d4c65c)
audit log (HistoryTable)
![image](https://github.com/user-attachments/assets/eba8a07c-4f09-460a-b5ca-b5aacf8ed9ec)

## new
draft modal
![image](https://github.com/user-attachments/assets/57ba0610-3565-42c1-a0d2-dce81f7d9e6f)
audit log (HistoryTable)
![image](https://github.com/user-attachments/assets/f3a0fefe-9bb7-4c37-b1af-c55bb57568a6)
