### PR TITLE
Experiment format naming validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -31,7 +31,7 @@ jobs:
           cache: 'yarn'
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: 3.11
           cache: 'pip'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v2
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache eslint
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.eslintcache
           key: ${{ runner.os }}-eslint-${{ hashFiles('**/yarn.lock') }}-${{ hashFiles('**/*.ts', '**/*.tsx') }}

--- a/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
+++ b/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
@@ -1,0 +1,31 @@
+import { FaInfoCircle } from "react-icons/fa";
+import clsx from "clsx";
+import Tooltip from "@/components/Tooltip/Tooltip";
+
+type Props = {
+  tipPosition?: "bottom" | "top" | "left" | "right";
+  className?: string;
+};
+
+export default function ExperimentNameFormatTooltip({
+  tipPosition = "top",
+  className,
+}: Props) {
+  return (
+    <Tooltip
+      body={
+        <>
+          Enter only the <code>&lt;experiment_name&gt;</code> portion from the
+          naming format{" "}
+          <code>exp1:&lt;experiment_name&gt;:&lt;variant_name&gt;</code>. Do not
+          include the <code>exp1:</code> prefix or the variation name.
+        </>
+      }
+      className={clsx("text-muted d-inline-flex align-items-center", className)}
+      style={{ cursor: "pointer" }}
+      tipPosition={tipPosition}
+    >
+      <FaInfoCircle />
+    </Tooltip>
+  );
+}

--- a/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
+++ b/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
@@ -1,3 +1,4 @@
+import { ReactNode } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 import clsx from "clsx";
 import Tooltip from "@/components/Tooltip/Tooltip";
@@ -5,21 +6,25 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 type Props = {
   tipPosition?: "bottom" | "top" | "left" | "right";
   className?: string;
+  body?: ReactNode;
 };
 
 export default function ExperimentNameFormatTooltip({
   tipPosition = "top",
   className,
+  body,
 }: Props) {
   return (
     <Tooltip
       body={
-        <>
-          Enter only the <code>&lt;experiment_name&gt;</code> portion from the
-          naming format{" "}
-          <code>exp1:&lt;experiment_name&gt;:&lt;variant_name&gt;</code>. Do not
-          include the <code>exp1:</code> prefix or the variation name.
-        </>
+        body ?? (
+          <>
+            Enter only the <code>&lt;experimentName&gt;</code> portion from the
+            naming format{" "}
+            <code>exp1:&lt;experimentName&gt;:&lt;variantName&gt;</code>. Do not
+            include the <code>exp1:</code> prefix or the variation name.
+          </>
+        )
       }
       className={clsx("text-muted d-inline-flex align-items-center", className)}
       style={{ cursor: "pointer" }}

--- a/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
+++ b/packages/front-end/components/Experiment/ExperimentNameFormatTooltip.tsx
@@ -1,4 +1,3 @@
-import { ReactNode } from "react";
 import { FaInfoCircle } from "react-icons/fa";
 import clsx from "clsx";
 import Tooltip from "@/components/Tooltip/Tooltip";
@@ -6,7 +5,7 @@ import Tooltip from "@/components/Tooltip/Tooltip";
 type Props = {
   tipPosition?: "bottom" | "top" | "left" | "right";
   className?: string;
-  body?: ReactNode;
+  body?: string | JSX.Element;
 };
 
 export default function ExperimentNameFormatTooltip({

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -92,7 +92,7 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
                     feature={info.feature}
                     showExperimentWarning={false}
                   />
-                  <CohortValidationWarning value={v} variationIndex={j} />
+                  <CohortValidationWarning value={v} />
                 </td>
               </tr>
             ))}

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -6,6 +6,10 @@ import { FaCheck, FaExclamationTriangle } from "react-icons/fa";
 import LinkedChange from "@/components/Experiment/LinkedChange";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import ForceSummary from "@/components/Features/ForceSummary";
+import {
+  validateCohort,
+  CohortValidationWarning,
+} from "@/components/Features/CohortValidation";
 
 type Props = {
   info: LinkedFeatureInfo;
@@ -76,20 +80,33 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
         <div className="font-weight-bold mb-2">Feature values</div>
         <table className="table table-sm table-bordered w-auto">
           <tbody>
-            {orderedValues.map((v, j) => (
-              <tr key={j}>
-                <td
-                  className={`px-3 variation with-variation-label with-variation-right-shadow border-right-0 variation${j}`}
-                >
-                  <span className="name font-weight-bold">
-                    {j}: {experiment.variations[j]?.name}
-                  </span>
-                </td>
-                <td className="px-3 border-left-0">
-                  <ForceSummary value={v} feature={info.feature} />
-                </td>
-              </tr>
-            ))}
+            {orderedValues.map((v, j) => {
+              const validation = validateCohort(
+                typeof v === "string" ? v : JSON.stringify(v ?? "")
+              );
+              return (
+                <tr key={j}>
+                  <td
+                    className={`px-3 variation with-variation-label with-variation-right-shadow border-right-0 variation${j}`}
+                  >
+                    <span className="name font-weight-bold">
+                      {j}: {experiment.variations[j]?.name}
+                    </span>
+                  </td>
+                  <td className="px-3 border-left-0">
+                    <ForceSummary
+                      value={v}
+                      feature={info.feature}
+                      showExperimentWarning={false}
+                    />
+                    <CohortValidationWarning
+                      validation={validation}
+                      variationIndex={j}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
 

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -7,8 +7,8 @@ import LinkedChange from "@/components/Experiment/LinkedChange";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import ForceSummary from "@/components/Features/ForceSummary";
 import {
-  validateCohort,
   CohortValidationWarning,
+  validateCohort,
 } from "@/components/Features/CohortValidation";
 
 type Props = {
@@ -80,33 +80,30 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
         <div className="font-weight-bold mb-2">Feature values</div>
         <table className="table table-sm table-bordered w-auto">
           <tbody>
-            {orderedValues.map((v, j) => {
-              const validation = validateCohort(
-                typeof v === "string" ? v : JSON.stringify(v ?? "")
-              );
-              return (
-                <tr key={j}>
-                  <td
-                    className={`px-3 variation with-variation-label with-variation-right-shadow border-right-0 variation${j}`}
-                  >
-                    <span className="name font-weight-bold">
-                      {j}: {experiment.variations[j]?.name}
-                    </span>
-                  </td>
-                  <td className="px-3 border-left-0">
-                    <ForceSummary
-                      value={v}
-                      feature={info.feature}
-                      showExperimentWarning={false}
-                    />
-                    <CohortValidationWarning
-                      validation={validation}
-                      variationIndex={j}
-                    />
-                  </td>
-                </tr>
-              );
-            })}
+            {orderedValues.map((v, j) => (
+              <tr key={j}>
+                <td
+                  className={`px-3 variation with-variation-label with-variation-right-shadow border-right-0 variation${j}`}
+                >
+                  <span className="name font-weight-bold">
+                    {j}: {experiment.variations[j]?.name}
+                  </span>
+                </td>
+                <td className="px-3 border-left-0">
+                  <ForceSummary
+                    value={v}
+                    feature={info.feature}
+                    showExperimentWarning={false}
+                  />
+                  <CohortValidationWarning
+                    validation={validateCohort(
+                      typeof v === "string" ? v : JSON.stringify(v ?? "")
+                    )}
+                    variationIndex={j}
+                  />
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
 

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -6,10 +6,7 @@ import { FaCheck, FaExclamationTriangle } from "react-icons/fa";
 import LinkedChange from "@/components/Experiment/LinkedChange";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import ForceSummary from "@/components/Features/ForceSummary";
-import {
-  CohortValidationWarning,
-  validateCohort,
-} from "@/components/Features/CohortValidation";
+import { CohortValidationWarning } from "@/components/Features/CohortValidation";
 
 type Props = {
   info: LinkedFeatureInfo;
@@ -95,10 +92,7 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
                     feature={info.feature}
                     showExperimentWarning={false}
                   />
-                  <CohortValidationWarning
-                    validation={validateCohort(v)}
-                    variationIndex={j}
-                  />
+                  <CohortValidationWarning value={v} variationIndex={j} />
                 </td>
               </tr>
             ))}

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -96,9 +96,7 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
                     showExperimentWarning={false}
                   />
                   <CohortValidationWarning
-                    validation={validateCohort(
-                      typeof v === "string" ? v : JSON.stringify(v ?? "")
-                    )}
+                    validation={validateCohort(v)}
                     variationIndex={j}
                   />
                 </td>

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -606,7 +606,6 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 : "This is just for documentation purposes and has no effect on the analysis."
             }
             showPreview={!!isNewExperiment}
-            showIdTooltip={true}
           />
         </div>
       </Page>

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -46,6 +46,7 @@ import SavedGroupTargetingField, {
   validateSavedGroupTargeting,
 } from "@/components/Features/SavedGroupTargetingField";
 import Toggle from "@/components/Forms/Toggle";
+import ExperimentNameFormatTooltip from "./ExperimentNameFormatTooltip";
 import ExperimentMetricsSelector from "./ExperimentMetricsSelector";
 
 const weekAgo = new Date();
@@ -378,7 +379,15 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
           )}
 
           <Field
-            label="Name"
+            label={
+              <span className="d-inline-flex align-items-center">
+                Name
+                <ExperimentNameFormatTooltip
+                  className="ml-1"
+                  tipPosition="right"
+                />
+              </span>
+            }
             required
             minLength={2}
             {...form.register("name")}

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -597,6 +597,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                 : "This is just for documentation purposes and has no effect on the analysis."
             }
             showPreview={!!isNewExperiment}
+            showIdTooltip={true}
           />
         </div>
       </Page>

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -43,13 +43,7 @@ export function validateCohort(value: string): CohortValidation {
   }
 }
 
-export function CohortValidationWarning({
-  value,
-  variationIndex,
-}: {
-  value: string;
-  variationIndex: number;
-}) {
+export function CohortValidationWarning({ value }: { value: string }) {
   const validation = validateCohort(value);
   if (validation.valid) return null;
 
@@ -60,25 +54,21 @@ export function CohortValidationWarning({
     >
       <FaExclamationTriangle className="mr-1" />
       {validation.reason === "not-json" ? (
-        <>
-          Invalid experiment setup. Variation {variationIndex} does not have a
-          json payload.
-        </>
+        <>Invalid experiment setup. Variation does not have a json payload.</>
       ) : validation.reason === "missing-cohort" ? (
         <>
-          Invalid experiment setup. Variation {variationIndex} does not have a{" "}
+          Invalid experiment setup. Variation does not have a{" "}
           <code>cohort</code> key.
         </>
       ) : validation.reason === "cohort-trailing-space" ? (
         <>
-          Invalid experiment setup. Variation {variationIndex} has trailing
-          whitespace in the cohort value. Please remove any spaces before or
-          after the value.
+          Invalid experiment setup. Variation has trailing whitespace in the
+          cohort value. Please remove any spaces before or after the value.
         </>
       ) : (
         <>
-          Invalid experiment setup. Variation {variationIndex} has an invalid
-          cohort value. Please follow the experiment naming format:{" "}
+          Invalid experiment setup. Variation has an invalid cohort value.
+          Please follow the experiment naming format:{" "}
           <code>
             exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
           </code>

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { FaExclamationTriangle } from "react-icons/fa";
+
+export type CohortValidation =
+  | { valid: true }
+  | { valid: false; reason: "not-json" }
+  | { valid: false; reason: "missing-cohort" }
+  | { valid: false; reason: "invalid-cohort-format" };
+
+export function validateCohort(value: string): CohortValidation {
+  try {
+    const parsed = JSON.parse(value);
+
+    // Check 1: Must be an object
+    if (typeof parsed !== "object" || parsed === null) {
+      return { valid: false, reason: "not-json" };
+    }
+
+    // Check 2: Must have cohort key
+    if (!("cohort" in parsed)) {
+      return { valid: false, reason: "missing-cohort" };
+    }
+
+    // Check 3: Cohort value must match format exp1:<somestr>:<somestr>
+    const cohortValue = parsed.cohort;
+    if (typeof cohortValue !== "string") {
+      return { valid: false, reason: "invalid-cohort-format" };
+    }
+
+    const cohortPattern = /^exp1:[^:]+:[^:]+$/;
+    if (!cohortPattern.test(cohortValue)) {
+      return { valid: false, reason: "invalid-cohort-format" };
+    }
+
+    return { valid: true };
+  } catch {
+    return { valid: false, reason: "not-json" };
+  }
+}
+
+export function CohortValidationWarning({
+  validation,
+  variationIndex,
+}: {
+  validation: CohortValidation;
+  variationIndex: number;
+}) {
+  if (validation.valid) return null;
+
+  return (
+    <tr>
+      <td colSpan={4}>
+        <div
+          className="alert alert-warning mb-0"
+          style={{ fontSize: "0.9em", padding: "0.5rem" }}
+        >
+          <FaExclamationTriangle className="mr-1" />
+          {validation.reason === "not-json" ? (
+            <>
+              Invalid experiment setup. Variation {variationIndex} does not have
+              a json payload.
+            </>
+          ) : validation.reason === "missing-cohort" ? (
+            <>
+              Invalid experiment setup. Variation {variationIndex} does not have
+              a <code>cohort</code> key.
+            </>
+          ) : (
+            <>
+              Invalid experiment setup. Variation {variationIndex} has an
+              invalid cohort format. Please follow the experiment naming format:{" "}
+              <code>
+                exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
+              </code>
+            </>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -48,35 +48,31 @@ export function CohortValidationWarning({
   if (validation.valid) return null;
 
   return (
-    <tr>
-      <td colSpan={4}>
-        <div
-          className="alert alert-warning mb-0"
-          style={{ fontSize: "0.9em", padding: "0.5rem" }}
-        >
-          <FaExclamationTriangle className="mr-1" />
-          {validation.reason === "not-json" ? (
-            <>
-              Invalid experiment setup. Variation {variationIndex} does not have
-              a json payload.
-            </>
-          ) : validation.reason === "missing-cohort" ? (
-            <>
-              Invalid experiment setup. Variation {variationIndex} does not have
-              a <code>cohort</code> key.
-            </>
-          ) : (
-            <>
-              Invalid experiment setup. Variation {variationIndex} has an
-              invalid cohort value. Please follow the experiment naming format:{" "}
-              <code>
-                exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
-              </code>
-            </>
-          )}
-        </div>
-      </td>
-    </tr>
+    <div
+      className="alert alert-warning mb-0 mt-2"
+      style={{ fontSize: "0.9em", padding: "0.5rem" }}
+    >
+      <FaExclamationTriangle className="mr-1" />
+      {validation.reason === "not-json" ? (
+        <>
+          Invalid experiment setup. Variation {variationIndex} does not have a
+          json payload.
+        </>
+      ) : validation.reason === "missing-cohort" ? (
+        <>
+          Invalid experiment setup. Variation {variationIndex} does not have a{" "}
+          <code>cohort</code> key.
+        </>
+      ) : (
+        <>
+          Invalid experiment setup. Variation {variationIndex} has an invalid
+          cohort value. Please follow the experiment naming format:{" "}
+          <code>
+            exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
+          </code>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -44,12 +44,13 @@ export function validateCohort(value: string): CohortValidation {
 }
 
 export function CohortValidationWarning({
-  validation,
+  value,
   variationIndex,
 }: {
-  validation: CohortValidation;
+  value: string;
   variationIndex: number;
 }) {
+  const validation = validateCohort(value);
   if (validation.valid) return null;
 
   return (

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -79,3 +79,40 @@ export function CohortValidationWarning({
     </tr>
   );
 }
+
+export function hasExperimentFormatCohort(value: string): boolean {
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed !== "object" || parsed === null) {
+      return false;
+    }
+    if (!("cohort" in parsed)) {
+      return false;
+    }
+
+    const cohortValue = parsed.cohort;
+    if (typeof cohortValue !== "string") {
+      return false;
+    }
+
+    const cohortPattern = /^exp1:[^:]+:[^:]+$/;
+    return cohortPattern.test(cohortValue);
+  } catch {
+    return false;
+  }
+}
+
+export function NonExperimentCohortWarning({ value }: { value: string }) {
+  if (!hasExperimentFormatCohort(value)) return null;
+
+  return (
+    <div
+      className="alert alert-warning"
+      style={{ fontSize: "0.9em", padding: "0.5rem" }}
+    >
+      <FaExclamationTriangle className="mr-1" />
+      Experiment naming format detected in non-experiment rule. Please rename so
+      it is not picked up by our experimentation infrastructure.
+    </div>
+  );
+}

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -68,7 +68,7 @@ export function CohortValidationWarning({
           ) : (
             <>
               Invalid experiment setup. Variation {variationIndex} has an
-              invalid cohort format. Please follow the experiment naming format:{" "}
+              invalid cohort value. Please follow the experiment naming format:{" "}
               <code>
                 exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
               </code>

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -5,7 +5,8 @@ export type CohortValidation =
   | { valid: true }
   | { valid: false; reason: "not-json" }
   | { valid: false; reason: "missing-cohort" }
-  | { valid: false; reason: "invalid-cohort-format" };
+  | { valid: false; reason: "invalid-cohort-format" }
+  | { valid: false; reason: "cohort-trailing-space" };
 
 export function validateCohort(value: string): CohortValidation {
   try {
@@ -30,6 +31,10 @@ export function validateCohort(value: string): CohortValidation {
     const cohortPattern = /^exp1:[^:]+:[^:]+$/;
     if (!cohortPattern.test(cohortValue)) {
       return { valid: false, reason: "invalid-cohort-format" };
+    }
+
+    if (cohortValue.trim() !== cohortValue) {
+      return { valid: false, reason: "cohort-trailing-space" };
     }
 
     return { valid: true };
@@ -63,6 +68,12 @@ export function CohortValidationWarning({
           Invalid experiment setup. Variation {variationIndex} does not have a{" "}
           <code>cohort</code> key.
         </>
+      ) : validation.reason === "cohort-trailing-space" ? (
+        <>
+          Invalid experiment setup. Variation {variationIndex} has trailing
+          whitespace in the cohort value. Please remove any spaces before or
+          after the value.
+        </>
       ) : (
         <>
           Invalid experiment setup. Variation {variationIndex} has an invalid
@@ -92,7 +103,10 @@ export function hasExperimentFormatCohort(value: string): boolean {
     }
 
     const cohortPattern = /^exp1:[^:]+:[^:]+$/;
-    return cohortPattern.test(cohortValue);
+    if (!cohortPattern.test(cohortValue)) {
+      return false;
+    }
+    return cohortValue.trim() === cohortValue;
   } catch {
     return false;
   }

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -243,6 +243,7 @@ export default function ExperimentRefSummary({
                     ?.value ?? "null";
 
                 const weight = phase.variationWeights?.[j] || 0;
+
                 return (
                   <tr key={j}>
                     <td

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -268,10 +268,7 @@ export default function ExperimentRefSummary({
                         defaultVal={featureDefault}
                       />
                       <ValidateValue value={value} feature={feature} />
-                      <CohortValidationWarning
-                        value={value}
-                        variationIndex={j}
-                      />
+                      <CohortValidationWarning value={value} />
                     </td>
                     <td>{variation.name}</td>
                     <td>

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -11,6 +11,7 @@ import ValueDisplay from "./ValueDisplay";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 import ConditionDisplay from "./ConditionDisplay";
 import ForceSummary from "./ForceSummary";
+import { validateCohort, CohortValidationWarning } from "./CohortValidation";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -242,48 +243,55 @@ export default function ExperimentRefSummary({
                     ?.value ?? "null";
 
                 const weight = phase.variationWeights?.[j] || 0;
+                const validation = validateCohort(value);
 
                 return (
-                  <tr key={j}>
-                    <td
-                      className="text-muted position-relative"
-                      style={{ fontSize: "0.9em", width: 25 }}
-                    >
-                      <div
-                        style={{
-                          width: "6px",
-                          position: "absolute",
-                          top: 0,
-                          bottom: 0,
-                          left: 0,
-                          backgroundColor: getVariationColor(j),
-                        }}
-                      />
-                      {j}.
-                    </td>
-                    <td>
-                      <ValueDisplay
-                        value={value}
-                        type={type}
-                        defaultVal={featureDefault}
-                      />
-                      <ValidateValue value={value} feature={feature} />
-                    </td>
-                    <td>{variation.name}</td>
-                    <td>
-                      <div className="d-flex">
+                  <React.Fragment key={j}>
+                    <CohortValidationWarning
+                      validation={validation}
+                      variationIndex={j}
+                    />
+                    <tr>
+                      <td
+                        className="text-muted position-relative"
+                        style={{ fontSize: "0.9em", width: 25 }}
+                      >
                         <div
                           style={{
-                            width: "4em",
-                            maxWidth: "4em",
-                            margin: "0 0 0 auto",
+                            width: "6px",
+                            position: "absolute",
+                            top: 0,
+                            bottom: 0,
+                            left: 0,
+                            backgroundColor: getVariationColor(j),
                           }}
-                        >
-                          {percentFormatter.format(weight)}
+                        />
+                        {j}.
+                      </td>
+                      <td>
+                        <ValueDisplay
+                          value={value}
+                          type={type}
+                          defaultVal={featureDefault}
+                        />
+                        <ValidateValue value={value} feature={feature} />
+                      </td>
+                      <td>{variation.name}</td>
+                      <td>
+                        <div className="d-flex">
+                          <div
+                            style={{
+                              width: "4em",
+                              maxWidth: "4em",
+                              margin: "0 0 0 auto",
+                            }}
+                          >
+                            {percentFormatter.format(weight)}
+                          </div>
                         </div>
-                      </div>
-                    </td>
-                  </tr>
+                      </td>
+                    </tr>
+                  </React.Fragment>
                 );
               })}
               <tr>

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -11,7 +11,7 @@ import ValueDisplay from "./ValueDisplay";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 import ConditionDisplay from "./ConditionDisplay";
 import ForceSummary from "./ForceSummary";
-import { validateCohort, CohortValidationWarning } from "./CohortValidation";
+import { CohortValidationWarning } from "./CohortValidation";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -243,8 +243,6 @@ export default function ExperimentRefSummary({
                     ?.value ?? "null";
 
                 const weight = phase.variationWeights?.[j] || 0;
-                const validation = validateCohort(value);
-
                 return (
                   <tr key={j}>
                     <td
@@ -271,7 +269,7 @@ export default function ExperimentRefSummary({
                       />
                       <ValidateValue value={value} feature={feature} />
                       <CohortValidationWarning
-                        validation={validation}
+                        value={value}
                         variationIndex={j}
                       />
                     </td>

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -246,52 +246,50 @@ export default function ExperimentRefSummary({
                 const validation = validateCohort(value);
 
                 return (
-                  <React.Fragment key={j}>
-                    <CohortValidationWarning
-                      validation={validation}
-                      variationIndex={j}
-                    />
-                    <tr>
-                      <td
-                        className="text-muted position-relative"
-                        style={{ fontSize: "0.9em", width: 25 }}
-                      >
+                  <tr key={j}>
+                    <td
+                      className="text-muted position-relative"
+                      style={{ fontSize: "0.9em", width: 25 }}
+                    >
+                      <div
+                        style={{
+                          width: "6px",
+                          position: "absolute",
+                          top: 0,
+                          bottom: 0,
+                          left: 0,
+                          backgroundColor: getVariationColor(j),
+                        }}
+                      />
+                      {j}.
+                    </td>
+                    <td>
+                      <ValueDisplay
+                        value={value}
+                        type={type}
+                        defaultVal={featureDefault}
+                      />
+                      <ValidateValue value={value} feature={feature} />
+                      <CohortValidationWarning
+                        validation={validation}
+                        variationIndex={j}
+                      />
+                    </td>
+                    <td>{variation.name}</td>
+                    <td>
+                      <div className="d-flex">
                         <div
                           style={{
-                            width: "6px",
-                            position: "absolute",
-                            top: 0,
-                            bottom: 0,
-                            left: 0,
-                            backgroundColor: getVariationColor(j),
+                            width: "4em",
+                            maxWidth: "4em",
+                            margin: "0 0 0 auto",
                           }}
-                        />
-                        {j}.
-                      </td>
-                      <td>
-                        <ValueDisplay
-                          value={value}
-                          type={type}
-                          defaultVal={featureDefault}
-                        />
-                        <ValidateValue value={value} feature={feature} />
-                      </td>
-                      <td>{variation.name}</td>
-                      <td>
-                        <div className="d-flex">
-                          <div
-                            style={{
-                              width: "4em",
-                              maxWidth: "4em",
-                              margin: "0 0 0 auto",
-                            }}
-                          >
-                            {percentFormatter.format(weight)}
-                          </div>
+                        >
+                          {percentFormatter.format(weight)}
                         </div>
-                      </td>
-                    </tr>
-                  </React.Fragment>
+                      </div>
+                    </td>
+                  </tr>
                 );
               })}
               <tr>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -13,6 +13,7 @@ import Modal from "@/components/Modal";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import ValueDisplay from "./ValueDisplay";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
+import { validateCohort, CohortValidationWarning } from "./CohortValidation";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -142,48 +143,57 @@ export default function ExperimentSummary({
 
       <table className="table mt-1 mb-3 bg-light gbtable">
         <tbody>
-          {values.map((r, j) => (
-            <tr key={j}>
-              <td
-                className="text-muted position-relative"
-                style={{ fontSize: "0.9em", width: 25 }}
-              >
-                <div
-                  style={{
-                    width: "6px",
-                    position: "absolute",
-                    top: 0,
-                    bottom: 0,
-                    left: 0,
-                    backgroundColor: getVariationColor(j),
-                  }}
+          {values.map((r, j) => {
+            const validation = validateCohort(r.value);
+            return (
+              <React.Fragment key={j}>
+                <CohortValidationWarning
+                  validation={validation}
+                  variationIndex={j}
                 />
-                {j}.
-              </td>
-              <td>
-                <ValueDisplay
-                  value={r.value}
-                  type={type}
-                  defaultVal={feature.defaultValue}
-                />
-                <ValidateValue value={r.value} feature={feature} />
-              </td>
-              <td>{r?.name}</td>
-              <td>
-                <div className="d-flex">
-                  <div
-                    style={{
-                      width: "4em",
-                      maxWidth: "4em",
-                      margin: "0 0 0 auto",
-                    }}
+                <tr>
+                  <td
+                    className="text-muted position-relative"
+                    style={{ fontSize: "0.9em", width: 25 }}
                   >
-                    {percentFormatter.format(r.weight)}
-                  </div>
-                </div>
-              </td>
-            </tr>
-          ))}
+                    <div
+                      style={{
+                        width: "6px",
+                        position: "absolute",
+                        top: 0,
+                        bottom: 0,
+                        left: 0,
+                        backgroundColor: getVariationColor(j),
+                      }}
+                    />
+                    {j}.
+                  </td>
+                  <td>
+                    <ValueDisplay
+                      value={r.value}
+                      type={type}
+                      defaultVal={feature.defaultValue}
+                    />
+                    <ValidateValue value={r.value} feature={feature} />
+                  </td>
+                  <td>{r?.name}</td>
+                  <td>
+                    <div className="d-flex">
+                      <div
+                        style={{
+                          width: "4em",
+                          maxWidth: "4em",
+                          margin: "0 0 0 auto",
+                        }}
+                      >
+                        {percentFormatter.format(r.weight)}
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </React.Fragment>
+            );
+          })}
           <tr>
             <td colSpan={4}>
               <ExperimentSplitVisual

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -13,7 +13,7 @@ import Modal from "@/components/Modal";
 import useOrgSettings from "@/hooks/useOrgSettings";
 import ValueDisplay from "./ValueDisplay";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
-import { validateCohort, CohortValidationWarning } from "./CohortValidation";
+import { CohortValidationWarning } from "./CohortValidation";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -168,10 +168,7 @@ export default function ExperimentSummary({
                   defaultVal={feature.defaultValue}
                 />
                 <ValidateValue value={r.value} feature={feature} />
-                <CohortValidationWarning
-                  validation={validateCohort(r.value)}
-                  variationIndex={j}
-                />
+                <CohortValidationWarning value={r.value} variationIndex={j} />
               </td>
               <td>{r?.name}</td>
               <td>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -143,55 +143,52 @@ export default function ExperimentSummary({
 
       <table className="table mt-1 mb-3 bg-light gbtable">
         <tbody>
-          {values.map((r, j) => {
-            const validation = validateCohort(r.value);
-            return (
-              <tr key={j}>
-                <td
-                  className="text-muted position-relative"
-                  style={{ fontSize: "0.9em", width: 25 }}
-                >
+          {values.map((r, j) => (
+            <tr key={j}>
+              <td
+                className="text-muted position-relative"
+                style={{ fontSize: "0.9em", width: 25 }}
+              >
+                <div
+                  style={{
+                    width: "6px",
+                    position: "absolute",
+                    top: 0,
+                    bottom: 0,
+                    left: 0,
+                    backgroundColor: getVariationColor(j),
+                  }}
+                />
+                {j}.
+              </td>
+              <td>
+                <ValueDisplay
+                  value={r.value}
+                  type={type}
+                  defaultVal={feature.defaultValue}
+                />
+                <ValidateValue value={r.value} feature={feature} />
+                <CohortValidationWarning
+                  validation={validateCohort(r.value)}
+                  variationIndex={j}
+                />
+              </td>
+              <td>{r?.name}</td>
+              <td>
+                <div className="d-flex">
                   <div
                     style={{
-                      width: "6px",
-                      position: "absolute",
-                      top: 0,
-                      bottom: 0,
-                      left: 0,
-                      backgroundColor: getVariationColor(j),
+                      width: "4em",
+                      maxWidth: "4em",
+                      margin: "0 0 0 auto",
                     }}
-                  />
-                  {j}.
-                </td>
-                <td>
-                  <ValueDisplay
-                    value={r.value}
-                    type={type}
-                    defaultVal={feature.defaultValue}
-                  />
-                  <ValidateValue value={r.value} feature={feature} />
-                  <CohortValidationWarning
-                    validation={validation}
-                    variationIndex={j}
-                  />
-                </td>
-                <td>{r?.name}</td>
-                <td>
-                  <div className="d-flex">
-                    <div
-                      style={{
-                        width: "4em",
-                        maxWidth: "4em",
-                        margin: "0 0 0 auto",
-                      }}
-                    >
-                      {percentFormatter.format(r.weight)}
-                    </div>
+                  >
+                    {percentFormatter.format(r.weight)}
                   </div>
-                </td>
-              </tr>
-            );
-          })}
+                </div>
+              </td>
+            </tr>
+          ))}
           <tr>
             <td colSpan={4}>
               <ExperimentSplitVisual

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -146,52 +146,50 @@ export default function ExperimentSummary({
           {values.map((r, j) => {
             const validation = validateCohort(r.value);
             return (
-              <React.Fragment key={j}>
-                <CohortValidationWarning
-                  validation={validation}
-                  variationIndex={j}
-                />
-                <tr>
-                  <td
-                    className="text-muted position-relative"
-                    style={{ fontSize: "0.9em", width: 25 }}
-                  >
+              <tr key={j}>
+                <td
+                  className="text-muted position-relative"
+                  style={{ fontSize: "0.9em", width: 25 }}
+                >
+                  <div
+                    style={{
+                      width: "6px",
+                      position: "absolute",
+                      top: 0,
+                      bottom: 0,
+                      left: 0,
+                      backgroundColor: getVariationColor(j),
+                    }}
+                  />
+                  {j}.
+                </td>
+                <td>
+                  <ValueDisplay
+                    value={r.value}
+                    type={type}
+                    defaultVal={feature.defaultValue}
+                  />
+                  <ValidateValue value={r.value} feature={feature} />
+                  <CohortValidationWarning
+                    validation={validation}
+                    variationIndex={j}
+                  />
+                </td>
+                <td>{r?.name}</td>
+                <td>
+                  <div className="d-flex">
                     <div
                       style={{
-                        width: "6px",
-                        position: "absolute",
-                        top: 0,
-                        bottom: 0,
-                        left: 0,
-                        backgroundColor: getVariationColor(j),
+                        width: "4em",
+                        maxWidth: "4em",
+                        margin: "0 0 0 auto",
                       }}
-                    />
-                    {j}.
-                  </td>
-                  <td>
-                    <ValueDisplay
-                      value={r.value}
-                      type={type}
-                      defaultVal={feature.defaultValue}
-                    />
-                    <ValidateValue value={r.value} feature={feature} />
-                  </td>
-                  <td>{r?.name}</td>
-                  <td>
-                    <div className="d-flex">
-                      <div
-                        style={{
-                          width: "4em",
-                          maxWidth: "4em",
-                          margin: "0 0 0 auto",
-                        }}
-                      >
-                        {percentFormatter.format(r.weight)}
-                      </div>
+                    >
+                      {percentFormatter.format(r.weight)}
                     </div>
-                  </td>
-                </tr>
-              </React.Fragment>
+                  </div>
+                </td>
+              </tr>
             );
           })}
           <tr>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -168,7 +168,7 @@ export default function ExperimentSummary({
                   defaultVal={feature.defaultValue}
                 />
                 <ValidateValue value={r.value} feature={feature} />
-                <CohortValidationWarning value={r.value} variationIndex={j} />
+                <CohortValidationWarning value={r.value} />
               </td>
               <td>{r?.name}</td>
               <td>

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -10,7 +10,7 @@ import dJSON from "dirty-json";
 import { ReactElement, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
-import { FaExternalLinkAlt, FaExclamationTriangle } from "react-icons/fa";
+import { FaExternalLinkAlt } from "react-icons/fa";
 import {
   filterEnvironmentsByExperiment,
   validateFeatureValue,
@@ -31,7 +31,10 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
-import { validateCohort } from "@/components/Features/CohortValidation";
+import {
+  validateCohort,
+  CohortValidationWarning,
+} from "@/components/Features/CohortValidation";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -432,37 +435,12 @@ export default function FeatureFromExperimentModal({
         <div className="mb-3 bg-light border p-3">
           {experiment.variations.map((v, i) => {
             const value = form.watch(`variations.${i}.value`) || "";
-            const validation = validateCohort(value);
             return (
               <div key={v.id}>
-                {!validation.valid && (
-                  <div
-                    className="alert alert-warning mb-2"
-                    style={{ fontSize: "0.9em", padding: "0.5rem" }}
-                  >
-                    <FaExclamationTriangle className="mr-1" />
-                    {validation.reason === "not-json" ? (
-                      <>
-                        Invalid experiment setup. Variation {i} does not have a
-                        json payload.
-                      </>
-                    ) : validation.reason === "missing-cohort" ? (
-                      <>
-                        Invalid experiment setup. Variation {i} does not have a{" "}
-                        <code>cohort</code> key.
-                      </>
-                    ) : (
-                      <>
-                        Invalid experiment setup. Variation {i} has an invalid
-                        cohort format. Please follow the experiment naming
-                        format:{" "}
-                        <code>
-                          exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
-                        </code>
-                      </>
-                    )}
-                  </div>
-                )}
+                <CohortValidationWarning
+                  validation={validateCohort(value)}
+                  variationIndex={i}
+                />
                 <FeatureValueField
                   label={v.name}
                   id={v.id}

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -10,7 +10,7 @@ import dJSON from "dirty-json";
 import { ReactElement, useState } from "react";
 import { ExperimentInterfaceStringDates } from "back-end/types/experiment";
 import Link from "next/link";
-import { FaExternalLinkAlt } from "react-icons/fa";
+import { FaExternalLinkAlt, FaExclamationTriangle } from "react-icons/fa";
 import {
   filterEnvironmentsByExperiment,
   validateFeatureValue,
@@ -31,6 +31,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { validateCohort } from "@/components/Features/CohortValidation";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -429,16 +430,49 @@ export default function FeatureFromExperimentModal({
       <div className="form-group">
         <label>Variation Values</label>
         <div className="mb-3 bg-light border p-3">
-          {experiment.variations.map((v, i) => (
-            <FeatureValueField
-              key={v.id}
-              label={v.name}
-              id={v.id}
-              value={form.watch(`variations.${i}.value`) || ""}
-              setValue={(v) => form.setValue(`variations.${i}.value`, v)}
-              valueType={form.watch("valueType")}
-            />
-          ))}
+          {experiment.variations.map((v, i) => {
+            const value = form.watch(`variations.${i}.value`) || "";
+            const validation = validateCohort(value);
+            return (
+              <div key={v.id}>
+                {!validation.valid && (
+                  <div
+                    className="alert alert-warning mb-2"
+                    style={{ fontSize: "0.9em", padding: "0.5rem" }}
+                  >
+                    <FaExclamationTriangle className="mr-1" />
+                    {validation.reason === "not-json" ? (
+                      <>
+                        Invalid experiment setup. Variation {i} does not have a
+                        json payload.
+                      </>
+                    ) : validation.reason === "missing-cohort" ? (
+                      <>
+                        Invalid experiment setup. Variation {i} does not have a{" "}
+                        <code>cohort</code> key.
+                      </>
+                    ) : (
+                      <>
+                        Invalid experiment setup. Variation {i} has an invalid
+                        cohort format. Please follow the experiment naming
+                        format:{" "}
+                        <code>
+                          exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
+                        </code>
+                      </>
+                    )}
+                  </div>
+                )}
+                <FeatureValueField
+                  label={v.name}
+                  id={v.id}
+                  value={value}
+                  setValue={(v) => form.setValue(`variations.${i}.value`, v)}
+                  valueType={form.watch("valueType")}
+                />
+              </div>
+            );
+          })}
         </div>
       </div>
 

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -31,10 +31,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import SelectField from "@/components/Forms/SelectField";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
-import {
-  validateCohort,
-  CohortValidationWarning,
-} from "@/components/Features/CohortValidation";
+import { CohortValidationWarning } from "@/components/Features/CohortValidation";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -437,10 +434,7 @@ export default function FeatureFromExperimentModal({
             const value = form.watch(`variations.${i}.value`) || "";
             return (
               <div key={v.id}>
-                <CohortValidationWarning
-                  validation={validateCohort(value)}
-                  variationIndex={i}
-                />
+                <CohortValidationWarning value={value} variationIndex={i} />
                 <FeatureValueField
                   label={v.name}
                   id={v.id}

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -434,7 +434,7 @@ export default function FeatureFromExperimentModal({
             const value = form.watch(`variations.${i}.value`) || "";
             return (
               <div key={v.id}>
-                <CohortValidationWarning value={value} variationIndex={i} />
+                <CohortValidationWarning value={value} />
                 <FeatureValueField
                   label={v.name}
                   id={v.id}

--- a/packages/front-end/components/Features/FeatureModal/index.tsx
+++ b/packages/front-end/components/Features/FeatureModal/index.tsx
@@ -22,6 +22,7 @@ import MarkdownInput from "@/components/Markdown/MarkdownInput";
 import { useDemoDataSourceProject } from "@/hooks/useDemoDataSourceProject";
 import FeatureValueField from "@/components/Features/FeatureValueField";
 import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { NonExperimentCohortWarning } from "@/components/Features/CohortValidation";
 import FeatureKeyField from "./FeatureKeyField";
 import EnvironmentSelect from "./EnvironmentSelect";
 import TagsField from "./TagsField";
@@ -317,6 +318,7 @@ export default function FeatureModal({
       */}
       {!featureToDuplicate && valueType && (
         <>
+          <NonExperimentCohortWarning value={form.watch("defaultValue")} />
           <FeatureValueField
             label={"Default Value when Enabled"}
             id="defaultValue"

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -1,6 +1,6 @@
 import { FeatureInterface, FeatureValueType } from "back-end/types/feature";
 import React, { useState } from "react";
-import { FaInfoCircle } from "react-icons/fa";
+import { FaInfoCircle, FaExclamationTriangle } from "react-icons/fa";
 import {
   decimalToPercent,
   distributeWeights,
@@ -38,6 +38,8 @@ export interface Props {
   label?: string;
   customSplitOn?: boolean;
   feature?: FeatureInterface;
+  showCohortValidation?: boolean;
+  showIdTooltip?: boolean;
 }
 
 export default function FeatureVariationsInput({
@@ -57,6 +59,8 @@ export default function FeatureVariationsInput({
   label,
   customSplitOn,
   feature,
+  showCohortValidation = false,
+  showIdTooltip = false,
 }: Props) {
   const weights = variations.map((v) => v.weight);
   const isEqualWeights = weights.every((w) => w === weights[0]);
@@ -135,7 +139,18 @@ export default function FeatureVariationsInput({
         <table className="table bg-light mb-0">
           <thead className={`${styles.variationSplitHeader}`}>
             <tr>
-              <th className="pl-3">Id</th>
+              <th className="pl-3">
+                {showIdTooltip ? (
+                  <Tooltip
+                    body="These are the variationNames from the experiment naming format exp1:<experimentName>:<variationName>"
+                    tipPosition="top"
+                  >
+                    Id <FaExclamationTriangle />
+                  </Tooltip>
+                ) : (
+                  "Id"
+                )}
+              </th>
               {!valueAsId && <th>Variation</th>}
               <th>
                 <Tooltip
@@ -188,6 +203,7 @@ export default function FeatureVariationsInput({
                   valueType={valueType}
                   valueAsId={valueAsId}
                   feature={feature}
+                  showCohortValidation={showCohortValidation}
                 />
               ))}
             </SortableVariationsList>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -40,7 +40,6 @@ export interface Props {
   customSplitOn?: boolean;
   feature?: FeatureInterface;
   showCohortValidation?: boolean;
-  showIdTooltip?: boolean;
 }
 
 export default function FeatureVariationsInput({
@@ -61,7 +60,6 @@ export default function FeatureVariationsInput({
   customSplitOn,
   feature,
   showCohortValidation = false,
-  showIdTooltip = false,
 }: Props) {
   const weights = variations.map((v) => v.weight);
   const isEqualWeights = weights.every((w) => w === weights[0]);
@@ -143,8 +141,20 @@ export default function FeatureVariationsInput({
               <th className="pl-3">
                 <span className="d-inline-flex align-items-center">
                   Id
-                  {showIdTooltip && (
-                    <ExperimentNameFormatTooltip className="ml-1" />
+                  {valueAsId && (
+                    <ExperimentNameFormatTooltip
+                      className="ml-1"
+                      body={
+                        <>
+                          These are the <code>&lt;variantName&gt;</code> values
+                          from the experiment naming format{" "}
+                          <code>
+                            exp1:&lt;experimentName&gt;:&lt;variantName&gt;
+                          </code>
+                          .
+                        </>
+                      }
+                    />
                   )}
                 </span>
               </th>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -1,6 +1,6 @@
 import { FeatureInterface, FeatureValueType } from "back-end/types/feature";
 import React, { useState } from "react";
-import { FaInfoCircle, FaExclamationTriangle } from "react-icons/fa";
+import { FaInfoCircle } from "react-icons/fa";
 import {
   decimalToPercent,
   distributeWeights,
@@ -13,6 +13,7 @@ import {
 } from "@/services/features";
 import { GBAddCircle } from "@/components/Icons";
 import Tooltip from "@/components/Tooltip/Tooltip";
+import ExperimentNameFormatTooltip from "@/components/Experiment/ExperimentNameFormatTooltip";
 import styles from "./VariationsInput.module.scss";
 import ExperimentSplitVisual from "./ExperimentSplitVisual";
 import {
@@ -140,16 +141,12 @@ export default function FeatureVariationsInput({
           <thead className={`${styles.variationSplitHeader}`}>
             <tr>
               <th className="pl-3">
-                {showIdTooltip ? (
-                  <Tooltip
-                    body="These are the variationNames from the experiment naming format exp1:<experimentName>:<variationName>"
-                    tipPosition="top"
-                  >
-                    Id <FaExclamationTriangle />
-                  </Tooltip>
-                ) : (
-                  "Id"
-                )}
+                <span className="d-inline-flex align-items-center">
+                  Id
+                  {showIdTooltip && (
+                    <ExperimentNameFormatTooltip className="ml-1" />
+                  )}
+                </span>
               </th>
               {!valueAsId && <th>Variation</th>}
               <th>

--- a/packages/front-end/components/Features/ForceSummary.tsx
+++ b/packages/front-end/components/Features/ForceSummary.tsx
@@ -1,6 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
 import ValidateValue from "@/components/Features/ValidateValue";
 import ValueDisplay from "./ValueDisplay";
+import { NonExperimentCohortWarning } from "./CohortValidation";
 
 export default function ForceSummary({
   value,
@@ -13,6 +14,7 @@ export default function ForceSummary({
 }) {
   return (
     <>
+      <NonExperimentCohortWarning value={value} />
       <div className="row align-items-top">
         <div className="col-auto">
           <strong>SERVE</strong>

--- a/packages/front-end/components/Features/ForceSummary.tsx
+++ b/packages/front-end/components/Features/ForceSummary.tsx
@@ -7,14 +7,16 @@ export default function ForceSummary({
   value,
   feature,
   isDefault = false,
+  showExperimentWarning = true,
 }: {
   value: string;
   feature: FeatureInterface;
   isDefault?: boolean;
+  showExperimentWarning?: boolean;
 }) {
   return (
     <>
-      <NonExperimentCohortWarning value={value} />
+      {showExperimentWarning && <NonExperimentCohortWarning value={value} />}
       <div className="row align-items-top">
         <div className="col-auto">
           <strong>SERVE</strong>

--- a/packages/front-end/components/Features/RolloutSummary.tsx
+++ b/packages/front-end/components/Features/RolloutSummary.tsx
@@ -1,6 +1,7 @@
 import { FeatureInterface } from "back-end/types/feature";
 import ValidateValue from "@/components/Features/ValidateValue";
 import ValueDisplay from "./ValueDisplay";
+import { NonExperimentCohortWarning } from "./CohortValidation";
 
 const percentFormatter = new Intl.NumberFormat(undefined, {
   style: "percent",
@@ -21,6 +22,7 @@ export default function RolloutSummary({
   const type = feature.valueType;
   return (
     <div>
+      <NonExperimentCohortWarning value={value} />
       <div className="mb-3">
         <strong className="mr-2">SAMPLE</strong> users by{" "}
         <span className="mr-1 border px-2 py-1 bg-light rounded">

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -62,7 +62,6 @@ import ScheduleInputs from "./ScheduleInputs";
 import FeatureVariationsInput from "./FeatureVariationsInput";
 import SavedGroupTargetingField from "./SavedGroupTargetingField";
 import {
-  validateCohort,
   NonExperimentCohortWarning,
   CohortValidationWarning,
 } from "./CohortValidation";
@@ -704,7 +703,7 @@ export default function RuleModal({
                   return (
                     <div key={v.id}>
                       <CohortValidationWarning
-                        validation={validateCohort(value)}
+                        value={value}
                         variationIndex={i}
                       />
                       <FeatureValueField

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -719,8 +719,8 @@ export default function RuleModal({
                           ) : (
                             <>
                               Invalid experiment setup. Variation {i} has an
-                              invalid cohort format. Please follow the
-                              experiment naming format:{" "}
+                              invalid cohort value. Please follow the experiment
+                              naming format:{" "}
                               <code>
                                 exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
                               </code>

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -61,7 +61,11 @@ import NamespaceSelector from "./NamespaceSelector";
 import ScheduleInputs from "./ScheduleInputs";
 import FeatureVariationsInput from "./FeatureVariationsInput";
 import SavedGroupTargetingField from "./SavedGroupTargetingField";
-import { validateCohort, NonExperimentCohortWarning } from "./CohortValidation";
+import {
+  validateCohort,
+  NonExperimentCohortWarning,
+  CohortValidationWarning,
+} from "./CohortValidation";
 
 export interface Props {
   close: () => void;
@@ -697,37 +701,12 @@ export default function RuleModal({
               <div className="mb-3 bg-light border p-3">
                 {selectedExperiment.variations.map((v, i) => {
                   const value = form.watch(`variations.${i}.value`) || "";
-                  const validation = validateCohort(value);
                   return (
                     <div key={v.id}>
-                      {!validation.valid && (
-                        <div
-                          className="alert alert-warning mb-2"
-                          style={{ fontSize: "0.9em", padding: "0.5rem" }}
-                        >
-                          <FaExclamationTriangle className="mr-1" />
-                          {validation.reason === "not-json" ? (
-                            <>
-                              Invalid experiment setup. Variation {i} does not
-                              have a json payload.
-                            </>
-                          ) : validation.reason === "missing-cohort" ? (
-                            <>
-                              Invalid experiment setup. Variation {i} does not
-                              have a <code>cohort</code> key.
-                            </>
-                          ) : (
-                            <>
-                              Invalid experiment setup. Variation {i} has an
-                              invalid cohort value. Please follow the experiment
-                              naming format:{" "}
-                              <code>
-                                exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
-                              </code>
-                            </>
-                          )}
-                        </div>
-                      )}
+                      <CohortValidationWarning
+                        validation={validateCohort(value)}
+                        variationIndex={i}
+                      />
                       <FeatureValueField
                         label={v.name}
                         id={v.id}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -61,7 +61,7 @@ import NamespaceSelector from "./NamespaceSelector";
 import ScheduleInputs from "./ScheduleInputs";
 import FeatureVariationsInput from "./FeatureVariationsInput";
 import SavedGroupTargetingField from "./SavedGroupTargetingField";
-import { validateCohort } from "./CohortValidation";
+import { validateCohort, NonExperimentCohortWarning } from "./CohortValidation";
 
 export interface Props {
   close: () => void;
@@ -762,19 +762,23 @@ export default function RuleModal({
         />
       )}
       {type === "force" && (
-        <FeatureValueField
-          label="Value to Force"
-          id="value"
-          value={form.watch("value")}
-          setValue={(v) => form.setValue("value", v)}
-          valueType={feature.valueType}
-          feature={feature}
-          renderJSONInline={true}
-        />
+        <>
+          <NonExperimentCohortWarning value={form.watch("value") || ""} />
+          <FeatureValueField
+            label="Value to Force"
+            id="value"
+            value={form.watch("value")}
+            setValue={(v) => form.setValue("value", v)}
+            valueType={feature.valueType}
+            feature={feature}
+            renderJSONInline={true}
+          />
+        </>
       )}
 
       {type === "rollout" && (
         <div>
+          <NonExperimentCohortWarning value={form.watch("value") || ""} />
           <FeatureValueField
             label="Value to roll out"
             id="value"

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -702,10 +702,7 @@ export default function RuleModal({
                   const value = form.watch(`variations.${i}.value`) || "";
                   return (
                     <div key={v.id}>
-                      <CohortValidationWarning
-                        value={value}
-                        variationIndex={i}
-                      />
+                      <CohortValidationWarning value={value} />
                       <FeatureValueField
                         label={v.name}
                         id={v.id}

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { FaArrowsAlt, FaExclamationTriangle } from "react-icons/fa";
+import { FaArrowsAlt } from "react-icons/fa";
 import {
   ExperimentValue,
   FeatureInterface,
@@ -23,7 +23,7 @@ import Field from "@/components/Forms/Field";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import FeatureValueField from "./FeatureValueField";
 import styles from "./VariationsInput.module.scss";
-import { validateCohort } from "./CohortValidation";
+import { validateCohort, CohortValidationWarning } from "./CohortValidation";
 
 export type SortableVariation = ExperimentValue & {
   id: string;
@@ -97,38 +97,12 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
         <td>
           {setVariations ? (
             <>
-              {showCohortValidation &&
-                (() => {
-                  const validation = validateCohort(variation.value);
-                  return !validation.valid ? (
-                    <div
-                      className="alert alert-warning mb-2"
-                      style={{ fontSize: "0.9em", padding: "0.5rem" }}
-                    >
-                      <FaExclamationTriangle className="mr-1" />
-                      {validation.reason === "not-json" ? (
-                        <>
-                          Invalid experiment setup. Variation {i} does not have
-                          a json payload.
-                        </>
-                      ) : validation.reason === "missing-cohort" ? (
-                        <>
-                          Invalid experiment setup. Variation {i} does not have
-                          a <code>cohort</code> key.
-                        </>
-                      ) : (
-                        <>
-                          Invalid experiment setup. Variation {i} has an invalid
-                          cohort format. Please follow the experiment naming
-                          format:{" "}
-                          <code>
-                            exp1:&lt;experimentNameInCamelCaseYYMMDD&gt;:&lt;variantName&gt;
-                          </code>
-                        </>
-                      )}
-                    </div>
-                  ) : null;
-                })()}
+              {showCohortValidation && (
+                <CohortValidationWarning
+                  validation={validateCohort(variation.value)}
+                  variationIndex={i}
+                />
+              )}
               <FeatureValueField
                 id={`value_${i}`}
                 value={variation.value}

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -23,7 +23,7 @@ import Field from "@/components/Forms/Field";
 import Tooltip from "@/components/Tooltip/Tooltip";
 import FeatureValueField from "./FeatureValueField";
 import styles from "./VariationsInput.module.scss";
-import { validateCohort, CohortValidationWarning } from "./CohortValidation";
+import { CohortValidationWarning } from "./CohortValidation";
 
 export type SortableVariation = ExperimentValue & {
   id: string;
@@ -99,7 +99,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
             <>
               {showCohortValidation && (
                 <CohortValidationWarning
-                  validation={validateCohort(variation.value)}
+                  value={variation.value}
                   variationIndex={i}
                 />
               )}

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -98,10 +98,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
           {setVariations ? (
             <>
               {showCohortValidation && (
-                <CohortValidationWarning
-                  value={variation.value}
-                  variationIndex={i}
-                />
+                <CohortValidationWarning value={variation.value} />
               )}
               <FeatureValueField
                 id={`value_${i}`}


### PR DESCRIPTION
### Features and Changes

<!--
  Include a description of your changes.
  If there are any new tools, API's, etc. that devs can leverage, it may be helpful to include usage info.
-->
Make UI updates to the experiment creation flow to nudge/prompt users to avoid common pitfalls when naming/setting things up.

<!--
  Indicate which issue this will close, if applicable
  For multiple issues, add a new `- Closes` or `- Fixes` line
-->

  - Built a reusable cohort validator that parses JSON payloads, enforces the
    cohort key format, and displays contextual warnings; hooked it into linked
    feature flags, experiment summaries, experiment-derived feature modals,
    rule modals, and sortable variation rows so misconfigurations are flagged
    wherever experiment values appear.
  - Introduced NonExperimentCohortWarning to catch experiment-style cohort
    values inside non-experiment rules, showing alerts in the default value
    editor, force/rollout editors, and force/rollout summaries to prevent
    accidental ingestion by experiment tooling.
  - Extended FeatureVariationsInput and SortableFeatureVariationRow with
    optional cohort validation wiring and enabled it for experiment rule
    editors, giving editors immediate feedback while entering variation
    payloads.
 - Added ExperimentNameFormatTooltip and bolted it onto the new experiment
    form plus variation tables so creators see inline instructions about
    providing only the <experimentName> or <variantName> segments from the
    exp1:<experimentName>:<variantName> pattern.

### Dependencies

<!--
Please include dependencies that must be met before deploying, if applicable. If none, you can write None or delete this section.
 -->

None

### Testing

<!--
  Please describe how to test these changes.
 -->
I've stepped through the different UI flows to make sure the validators behave as expected.

### Screenshots

<!--
  For any UI changes, e.g. changes to /front-end or docs components, please include screenshots
-->
<img width="1376" height="949" alt="Screenshot 2025-11-13 at 2 16 26 AM" src="https://github.com/user-attachments/assets/22913e8e-c59d-408b-b86a-4d6ef43e35b7" />
<img width="1300" height="953" alt="Screenshot 2025-11-13 at 2 16 55 AM" src="https://github.com/user-attachments/assets/c8486221-93d6-4873-8983-2300bd8575b9" />
<img width="1300" height="953" alt="Screenshot 2025-11-13 at 2 17 14 AM" src="https://github.com/user-attachments/assets/877fde1c-b081-47db-964a-3f780bbf5492" />
<img width="1300" height="953" alt="Screenshot 2025-11-13 at 2 17 43 AM" src="https://github.com/user-attachments/assets/959506d1-d0f2-4a16-80e6-d334f6cd0c1d" />
