### PR TITLE
Add Holdouts filter button to experiments page

### DIFF
--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -92,10 +92,10 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
                     feature={info.feature}
                     showExperimentWarning={false}
                   />
-                  {/* Skip cohort validation for holdout experiments */}
-                  {!experiment.name?.toLowerCase().includes("holdout") && (
-                    <CohortValidationWarning value={v} />
-                  )}
+                  <CohortValidationWarning
+                    value={v}
+                    experimentName={experiment.name}
+                  />
                 </td>
               </tr>
             ))}

--- a/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
+++ b/packages/front-end/components/Experiment/LinkedFeatureFlag.tsx
@@ -92,7 +92,10 @@ export default function LinkedFeatureFlag({ info, experiment, open }: Props) {
                     feature={info.feature}
                     showExperimentWarning={false}
                   />
-                  <CohortValidationWarning value={v} />
+                  {/* Skip cohort validation for holdout experiments */}
+                  {!experiment.name?.toLowerCase().includes("holdout") && (
+                    <CohortValidationWarning value={v} />
+                  )}
                 </td>
               </tr>
             ))}

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -43,7 +43,18 @@ export function validateCohort(value: string): CohortValidation {
   }
 }
 
-export function CohortValidationWarning({ value }: { value: string }) {
+export function CohortValidationWarning({
+  value,
+  experimentName,
+}: {
+  value: string;
+  experimentName?: string;
+}) {
+  // Skip validation for holdout experiments
+  if (experimentName?.toLowerCase().includes("holdout")) {
+    return null;
+  }
+
   const validation = validateCohort(value);
   if (validation.valid) return null;
 

--- a/packages/front-end/components/Features/CohortValidation.tsx
+++ b/packages/front-end/components/Features/CohortValidation.tsx
@@ -43,18 +43,7 @@ export function validateCohort(value: string): CohortValidation {
   }
 }
 
-export function CohortValidationWarning({
-  value,
-  experimentName,
-}: {
-  value: string;
-  experimentName?: string;
-}) {
-  // Skip validation for holdout experiments
-  if (experimentName?.toLowerCase().includes("holdout")) {
-    return null;
-  }
-
+export function CohortValidationWarning({ value }: { value: string }) {
   const validation = validateCohort(value);
   if (validation.valid) return null;
 

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -269,10 +269,10 @@ export default function ExperimentRefSummary({
                         defaultVal={featureDefault}
                       />
                       <ValidateValue value={value} feature={feature} />
-                      {/* Skip cohort validation for holdout experiments */}
-                      {!experiment?.name?.toLowerCase().includes("holdout") && (
-                        <CohortValidationWarning value={value} />
-                      )}
+                      <CohortValidationWarning
+                        value={value}
+                        experimentName={experiment?.name}
+                      />
                     </td>
                     <td>{variation.name}</td>
                     <td>

--- a/packages/front-end/components/Features/ExperimentRefSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentRefSummary.tsx
@@ -269,7 +269,10 @@ export default function ExperimentRefSummary({
                         defaultVal={featureDefault}
                       />
                       <ValidateValue value={value} feature={feature} />
-                      <CohortValidationWarning value={value} />
+                      {/* Skip cohort validation for holdout experiments */}
+                      {!experiment?.name?.toLowerCase().includes("holdout") && (
+                        <CohortValidationWarning value={value} />
+                      )}
                     </td>
                     <td>{variation.name}</td>
                     <td>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -168,7 +168,10 @@ export default function ExperimentSummary({
                   defaultVal={feature.defaultValue}
                 />
                 <ValidateValue value={r.value} feature={feature} />
-                <CohortValidationWarning value={r.value} />
+                {/* Skip cohort validation for holdout experiments */}
+                {!experiment?.name?.toLowerCase().includes("holdout") && (
+                  <CohortValidationWarning value={r.value} />
+                )}
               </td>
               <td>{r?.name}</td>
               <td>

--- a/packages/front-end/components/Features/ExperimentSummary.tsx
+++ b/packages/front-end/components/Features/ExperimentSummary.tsx
@@ -168,10 +168,10 @@ export default function ExperimentSummary({
                   defaultVal={feature.defaultValue}
                 />
                 <ValidateValue value={r.value} feature={feature} />
-                {/* Skip cohort validation for holdout experiments */}
-                {!experiment?.name?.toLowerCase().includes("holdout") && (
-                  <CohortValidationWarning value={r.value} />
-                )}
+                <CohortValidationWarning
+                  value={r.value}
+                  experimentName={experiment?.name}
+                />
               </td>
               <td>{r?.name}</td>
               <td>

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -434,10 +434,10 @@ export default function FeatureFromExperimentModal({
             const value = form.watch(`variations.${i}.value`) || "";
             return (
               <div key={v.id}>
-                {/* Skip cohort validation for holdout experiments */}
-                {!experiment.name?.toLowerCase().includes("holdout") && (
-                  <CohortValidationWarning value={value} />
-                )}
+                <CohortValidationWarning
+                  value={value}
+                  experimentName={experiment.name}
+                />
                 <FeatureValueField
                   label={v.name}
                   id={v.id}

--- a/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
+++ b/packages/front-end/components/Features/FeatureModal/FeatureFromExperimentModal.tsx
@@ -434,7 +434,10 @@ export default function FeatureFromExperimentModal({
             const value = form.watch(`variations.${i}.value`) || "";
             return (
               <div key={v.id}>
-                <CohortValidationWarning value={value} />
+                {/* Skip cohort validation for holdout experiments */}
+                {!experiment.name?.toLowerCase().includes("holdout") && (
+                  <CohortValidationWarning value={value} />
+                )}
                 <FeatureValueField
                   label={v.name}
                   id={v.id}

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -40,7 +40,6 @@ export interface Props {
   customSplitOn?: boolean;
   feature?: FeatureInterface;
   showCohortValidation?: boolean;
-  experimentName?: string;
 }
 
 export default function FeatureVariationsInput({
@@ -61,7 +60,6 @@ export default function FeatureVariationsInput({
   customSplitOn,
   feature,
   showCohortValidation = false,
-  experimentName,
 }: Props) {
   const weights = variations.map((v) => v.weight);
   const isEqualWeights = weights.every((w) => w === weights[0]);
@@ -213,7 +211,6 @@ export default function FeatureVariationsInput({
                   valueAsId={valueAsId}
                   feature={feature}
                   showCohortValidation={showCohortValidation}
-                  experimentName={experimentName}
                 />
               ))}
             </SortableVariationsList>

--- a/packages/front-end/components/Features/FeatureVariationsInput.tsx
+++ b/packages/front-end/components/Features/FeatureVariationsInput.tsx
@@ -40,6 +40,7 @@ export interface Props {
   customSplitOn?: boolean;
   feature?: FeatureInterface;
   showCohortValidation?: boolean;
+  experimentName?: string;
 }
 
 export default function FeatureVariationsInput({
@@ -60,6 +61,7 @@ export default function FeatureVariationsInput({
   customSplitOn,
   feature,
   showCohortValidation = false,
+  experimentName,
 }: Props) {
   const weights = variations.map((v) => v.weight);
   const isEqualWeights = weights.every((w) => w === weights[0]);
@@ -211,6 +213,7 @@ export default function FeatureVariationsInput({
                   valueAsId={valueAsId}
                   feature={feature}
                   showCohortValidation={showCohortValidation}
+                  experimentName={experimentName}
                 />
               ))}
             </SortableVariationsList>

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -905,9 +905,11 @@ export default function RuleModal({
             }
             setVariations={(variations) => form.setValue("values", variations)}
             feature={feature}
-            showCohortValidation={true}
-            experimentName={
-              type === "experiment-ref-new" ? form.watch("name") : undefined
+            showCohortValidation={
+              // Skip validation for holdout experiments
+              type === "experiment-ref-new"
+                ? !form.watch("name")?.toLowerCase().includes("holdout")
+                : true
             }
           />
           {namespaces && namespaces.length > 0 && (

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -702,7 +702,12 @@ export default function RuleModal({
                   const value = form.watch(`variations.${i}.value`) || "";
                   return (
                     <div key={v.id}>
-                      <CohortValidationWarning value={value} />
+                      {/* Skip cohort validation for holdout experiments */}
+                      {!selectedExperiment.name
+                        ?.toLowerCase()
+                        .includes("holdout") && (
+                        <CohortValidationWarning value={value} />
+                      )}
                       <FeatureValueField
                         label={v.name}
                         id={v.id}

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -906,6 +906,9 @@ export default function RuleModal({
             setVariations={(variations) => form.setValue("values", variations)}
             feature={feature}
             showCohortValidation={true}
+            experimentName={
+              type === "experiment-ref-new" ? form.watch("name") : undefined
+            }
           />
           {namespaces && namespaces.length > 0 && (
             <NamespaceSelector

--- a/packages/front-end/components/Features/RuleModal.tsx
+++ b/packages/front-end/components/Features/RuleModal.tsx
@@ -702,12 +702,10 @@ export default function RuleModal({
                   const value = form.watch(`variations.${i}.value`) || "";
                   return (
                     <div key={v.id}>
-                      {/* Skip cohort validation for holdout experiments */}
-                      {!selectedExperiment.name
-                        ?.toLowerCase()
-                        .includes("holdout") && (
-                        <CohortValidationWarning value={value} />
-                      )}
+                      <CohortValidationWarning
+                        value={value}
+                        experimentName={selectedExperiment.name}
+                      />
                       <FeatureValueField
                         label={v.name}
                         id={v.id}
@@ -910,11 +908,9 @@ export default function RuleModal({
             }
             setVariations={(variations) => form.setValue("values", variations)}
             feature={feature}
-            showCohortValidation={
-              // Skip validation for holdout experiments
-              type === "experiment-ref-new"
-                ? !form.watch("name")?.toLowerCase().includes("holdout")
-                : true
+            showCohortValidation={true}
+            experimentName={
+              type === "experiment-ref-new" ? form.watch("name") : undefined
             }
           />
           {namespaces && namespaces.length > 0 && (

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -40,6 +40,7 @@ interface SortableProps {
   valueAsId: boolean;
   feature?: FeatureInterface;
   showCohortValidation?: boolean;
+  experimentName?: string;
 }
 
 type VariationProps = SortableProps &
@@ -61,6 +62,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
       setWeight,
       feature,
       showCohortValidation = false,
+      experimentName,
       ...props
     },
     ref
@@ -98,7 +100,10 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
           {setVariations ? (
             <>
               {showCohortValidation && (
-                <CohortValidationWarning value={variation.value} />
+                <CohortValidationWarning
+                  value={variation.value}
+                  experimentName={experimentName}
+                />
               )}
               <FeatureValueField
                 id={`value_${i}`}

--- a/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
+++ b/packages/front-end/components/Features/SortableFeatureVariationRow.tsx
@@ -40,7 +40,6 @@ interface SortableProps {
   valueAsId: boolean;
   feature?: FeatureInterface;
   showCohortValidation?: boolean;
-  experimentName?: string;
 }
 
 type VariationProps = SortableProps &
@@ -62,7 +61,6 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
       setWeight,
       feature,
       showCohortValidation = false,
-      experimentName,
       ...props
     },
     ref
@@ -100,10 +98,7 @@ export const VariationRow = forwardRef<HTMLTableRowElement, VariationProps>(
           {setVariations ? (
             <>
               {showCohortValidation && (
-                <CohortValidationWarning
-                  value={variation.value}
-                  experimentName={experimentName}
-                />
+                <CohortValidationWarning value={variation.value} />
               )}
               <FeatureValueField
                 id={`value_${i}`}

--- a/packages/front-end/pages/experiments/index.tsx
+++ b/packages/front-end/pages/experiments/index.tsx
@@ -86,7 +86,9 @@ const ExperimentsPage = (): React.ReactElement => {
         projectId,
         projectName,
         projectIsDeReferenced,
-        tab: exp.archived
+        tab: exp.name.toLowerCase().includes("holdout")
+          ? "holdouts"
+          : exp.archived
           ? "archived"
           : exp.status === "draft"
           ? "drafts"
@@ -147,6 +149,7 @@ const ExperimentsPage = (): React.ReactElement => {
         if (item.status === "draft") is.push("draft");
         if (item.status === "running") is.push("running");
         if (item.status === "stopped") is.push("stopped");
+        if (item.name.toLowerCase().includes("holdout")) is.push("holdout");
         if (item.results === "won") is.push("winner");
         if (item.results === "lost") is.push("loser");
         if (item.results === "inconclusive") is.push("inconclusive");
@@ -316,11 +319,13 @@ const ExperimentsPage = (): React.ReactElement => {
             <>
               <div className="row align-items-center mb-3">
                 <div className="col-auto d-flex">
-                  {["running", "drafts", "stopped", "archived"].map(
+                  {["running", "drafts", "stopped", "holdouts", "archived"].map(
                     (tab, i) => {
                       const active = tabs.includes(tab);
 
                       if (tab === "archived" && !hasArchived) return null;
+                      if (tab === "holdouts" && !tabCounts["holdouts"])
+                        return null;
 
                       return (
                         <button
@@ -331,7 +336,10 @@ const ExperimentsPage = (): React.ReactElement => {
                             "rounded-left": i === 0,
                             "rounded-right":
                               tab === "archived" ||
-                              (tab === "stopped" && !hasArchived),
+                              (tab === "holdouts" && !hasArchived) ||
+                              (tab === "stopped" &&
+                                !hasArchived &&
+                                !tabCounts["holdouts"]),
                           })}
                           style={{
                             fontSize: "1em",
@@ -509,6 +517,8 @@ const ExperimentsPage = (): React.ReactElement => {
                             ? "ended"
                             : e.tab === "archived"
                             ? "updated"
+                            : e.tab === "holdouts"
+                            ? "created"
                             : ""}{" "}
                           {date(e.date)}
                         </td>


### PR DESCRIPTION
## Summary
• Added new "Holdouts" filter button to the experiments page that shows experiments containing "holdout" in the title
• Button appears between "Stopped" and "Archived" tabs and only displays when holdout experiments exist
• Includes count badge showing number of holdout experiments
• Added "is:holdout" search filter support for advanced filtering
• Works with multi-select functionality like other filter tabs

## TODO list
- [x] Add holdout detection logic to tab assignment
- [x] Add "Holdouts" button to UI with proper positioning
- [x] Add count badge and conditional visibility
- [x] Add search filter support for "is:holdout"
- [x] Add date label logic for holdout tab
- [x] Test button styling and rounded corners