### PR TITLE
Add feature flag changes history page

### DIFF
--- a/packages/front-end/components/Features/FeatureHistory/FeatureHistoryPage.tsx
+++ b/packages/front-end/components/Features/FeatureHistory/FeatureHistoryPage.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from "react";
+import Link from "next/link";
+import { EventInterface } from "back-end/types/event";
+import { FaSort, FaSortDown, FaSortUp } from "react-icons/fa";
+import useApi from "@/hooks/useApi";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import Pagination from "@/components/Pagination";
+import Field from "@/components/Forms/Field";
+import SelectField from "@/components/Forms/SelectField";
+import usePermissionsUtil from "@/hooks/usePermissionsUtils";
+import { FeatureHistoryRow } from "./FeatureHistoryRow";
+import { buildFeatureHistoryFilterParams, FEATURE_EVENT_TYPES } from "./utils";
+
+export const FeatureHistoryPage: React.FC = () => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [perPage, setPerPage] = useState(30);
+  const [fromDate, setFromDate] = useState<Date | null>(null);
+  const [toDate, setToDate] = useState<Date | null>(null);
+  const [sort, setSort] = useState<{ field: string; dir: number }>({
+    field: "dateCreated",
+    dir: -1,
+  });
+
+  const permissionsUtil = usePermissionsUtil();
+
+  const sortOrder = sort.dir === 1 ? "asc" : "desc";
+  const filterURLParams = buildFeatureHistoryFilterParams({
+    currentPage,
+    perPage,
+    fromDate,
+    toDate,
+    sortOrder,
+  });
+
+  const { data, error } = useApi<{ events: EventInterface[] }>(
+    "/events?" + filterURLParams
+  );
+
+  const { data: countData } = useApi<{ count: number }>(
+    "/events/count?type=" +
+      JSON.stringify([...FEATURE_EVENT_TYPES]) +
+      (fromDate ? "&from=" + fromDate.toISOString() : "") +
+      (toDate ? "&to=" + toDate.toISOString() : "")
+  );
+
+  const hasFilters = !!fromDate || !!toDate;
+
+  if (!permissionsUtil.canViewAuditLogs()) {
+    return (
+      <div className="container pagecontents">
+        <div className="alert alert-danger">
+          You do not have access to view this page.
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <LoadingSpinner />;
+  }
+
+  const events = data.events;
+
+  return (
+    <div className="container py-4">
+      <div className="row mb-3">
+        <div className="col">
+          <Link href="/features" className="text-muted">
+            &larr; Back to Features
+          </Link>
+          <h1 className="mt-2">Feature Flag Changes History</h1>
+          <p className="text-muted">
+            View all changes made to feature flags within a date range.
+          </p>
+        </div>
+      </div>
+
+      <div className="d-flex justify-content-between flex-row mt-2">
+        <div>
+          <Field
+            type="date"
+            label="From"
+            className="text-muted"
+            labelClassName="mr-2 mb-0"
+            containerClassName="d-flex align-items-center mb-0"
+            value={fromDate ? fromDate.toISOString().split("T")[0] : ""}
+            onChange={(e) => {
+              setFromDate(e.target.value ? new Date(e.target.value) : null);
+              setCurrentPage(1);
+            }}
+          />
+        </div>
+        <div>
+          <Field
+            type="date"
+            label="To"
+            className="text-muted"
+            labelClassName="mr-2 mb-0"
+            containerClassName="ml-2 d-flex align-items-center mb-0"
+            value={toDate ? toDate.toISOString().split("T")[0] : ""}
+            onChange={(e) => {
+              setToDate(e.target.value ? new Date(e.target.value) : null);
+              setCurrentPage(1);
+            }}
+          />
+        </div>
+        {hasFilters && (
+          <div>
+            <button
+              className="btn btn-outline-info ml-2"
+              onClick={(e) => {
+                e.preventDefault();
+                setFromDate(null);
+                setToDate(null);
+                setCurrentPage(1);
+              }}
+            >
+              Clear
+            </button>
+          </div>
+        )}
+        <div className="flex-grow-1"></div>
+        <div>
+          <SelectField
+            containerClassName="ml-2 d-flex align-items-center mb-0"
+            labelClassName="mr-2 mb-0"
+            label="Show"
+            options={[
+              { label: "10", value: "10" },
+              { label: "20", value: "20" },
+              { label: "30", value: "30" },
+              { label: "50", value: "50" },
+              { label: "100", value: "100" },
+            ]}
+            sort={false}
+            value={"" + perPage}
+            onChange={(v) => {
+              if (parseInt(v) === perPage) return;
+              setPerPage(parseInt(v));
+              setCurrentPage(1);
+            }}
+          />
+        </div>
+      </div>
+
+      {error && (
+        <div className="alert alert-danger mt-2">
+          There was an error loading the events.
+        </div>
+      )}
+
+      <table className="mt-3 table gbtable appbox--align-top table-hover appbox">
+        <thead>
+          <tr>
+            <th style={{ width: 180 }}>
+              <span
+                className="cursor-pointer"
+                onClick={(e) => {
+                  e.preventDefault();
+                  setSort({
+                    field: "dateCreated",
+                    dir: sort.dir * -1,
+                  });
+                }}
+              >
+                Date/Time{" "}
+                <a
+                  href="#"
+                  className={
+                    sort.field === "dateCreated" ? "activesort" : "inactivesort"
+                  }
+                >
+                  {sort.field === "dateCreated" ? (
+                    sort.dir < 0 ? (
+                      <FaSortDown />
+                    ) : (
+                      <FaSortUp />
+                    )
+                  ) : (
+                    <FaSort />
+                  )}
+                </a>
+              </span>
+            </th>
+            <th style={{ width: 200 }}>Feature</th>
+            <th style={{ width: 100 }}>Event Type</th>
+            <th style={{ width: 150 }}>User</th>
+            <th>Changes</th>
+            <th style={{ width: 50 }}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {events.length === 0 ? (
+            <tr>
+              <td colSpan={6}>
+                {hasFilters ? (
+                  <div className="text-center py-4">
+                    No feature changes were found that match the filters.
+                  </div>
+                ) : (
+                  <div className="text-center py-4">
+                    No feature changes were found. Feature changes are recorded
+                    when users create, update, or delete feature flags.
+                  </div>
+                )}
+              </td>
+            </tr>
+          ) : (
+            events.map((event) => (
+              <FeatureHistoryRow key={event.id} event={event} />
+            ))
+          )}
+        </tbody>
+      </table>
+
+      <Pagination
+        currentPage={currentPage}
+        numItemsTotal={countData?.count || 0}
+        perPage={perPage}
+        onPageChange={(page) => {
+          setCurrentPage(page);
+        }}
+      />
+    </div>
+  );
+};

--- a/packages/front-end/components/Features/FeatureHistory/FeatureHistoryRow.tsx
+++ b/packages/front-end/components/Features/FeatureHistory/FeatureHistoryRow.tsx
@@ -1,0 +1,203 @@
+import React, { useState } from "react";
+import Link from "next/link";
+import { EventInterface } from "back-end/types/event";
+import { datetime } from "shared/dates";
+import { FaAngleDown, FaAngleUp } from "react-icons/fa";
+import Code from "@/components/SyntaxHighlighting/Code";
+import JsonDiff from "@/components/Features/JsonDiff";
+import { formatEventType, getFeatureChangesSummary } from "./utils";
+
+type FeatureHistoryRowProps = {
+  event: EventInterface;
+};
+
+// Type for feature event data structure
+interface FeatureEventData {
+  object?: Record<string, unknown>;
+  current?: Record<string, unknown>;
+  previous?: Record<string, unknown>;
+  previous_attributes?: Record<string, unknown>;
+}
+
+function getEventData(event: EventInterface): FeatureEventData {
+  return (event.data.data as unknown) as FeatureEventData;
+}
+
+function getFeatureId(event: EventInterface): string {
+  const eventData = getEventData(event);
+
+  if (event.version) {
+    return (eventData?.object?.id as string) || "unknown";
+  }
+  // Legacy format
+  return (
+    (eventData?.current?.id as string) ||
+    (eventData?.previous?.id as string) ||
+    "unknown"
+  );
+}
+
+function getUserDisplay(event: EventInterface): string {
+  if (!event.data?.user) return "";
+  if ("name" in event.data.user && event.data.user.name) {
+    return event.data.user.name;
+  }
+  if ("email" in event.data.user && event.data.user.email) {
+    return event.data.user.email;
+  }
+  return "";
+}
+
+function getUserEmail(event: EventInterface): string {
+  if (!event.data?.user) return "";
+  if ("email" in event.data.user) {
+    return event.data.user.email || "";
+  }
+  return "";
+}
+
+function getPreviousAttributes(
+  event: EventInterface
+): Record<string, unknown> | undefined {
+  const eventData = getEventData(event);
+  return eventData?.previous_attributes;
+}
+
+function getCurrentState(
+  event: EventInterface
+): Record<string, unknown> | null {
+  const eventData = getEventData(event);
+  if (event.version) {
+    return eventData?.object || null;
+  }
+  return eventData?.current || null;
+}
+
+function getPreviousState(
+  event: EventInterface
+): Record<string, unknown> | null {
+  const eventData = getEventData(event);
+  const previousAttributes = eventData?.previous_attributes;
+
+  // For updates, reconstruct previous state from current + previous_attributes
+  if (previousAttributes && Object.keys(previousAttributes).length > 0) {
+    const currentState = getCurrentState(event);
+    if (currentState) {
+      // Previous state = current state with changed fields replaced by old values
+      return { ...currentState, ...previousAttributes };
+    }
+  }
+
+  // For deletes or legacy format
+  if (event.version) {
+    return eventData?.object || null;
+  }
+  return eventData?.previous || eventData?.current || null;
+}
+
+export const FeatureHistoryRow: React.FC<FeatureHistoryRowProps> = ({
+  event,
+}) => {
+  const [showDetails, setShowDetails] = useState(false);
+
+  const featureId = getFeatureId(event);
+  const eventType = event.data.event || event.event;
+  const userDisplay = getUserDisplay(event);
+  const userEmail = getUserEmail(event);
+  const previousAttributes = getPreviousAttributes(event);
+  const changesSummary = getFeatureChangesSummary(
+    eventType,
+    previousAttributes
+  );
+
+  const currentState = getCurrentState(event);
+  const previousState = getPreviousState(event);
+  const isUpdate = eventType === "feature.updated";
+  const canShowDiff = isUpdate && previousState && currentState;
+
+  return (
+    <>
+      <tr>
+        <td>
+          <span className="py-1 d-block nowrap">
+            {datetime(event.dateCreated)}
+          </span>
+        </td>
+        <td>
+          <Link href={`/features/${featureId}`} className="font-weight-bold">
+            {featureId}
+          </Link>
+        </td>
+        <td>
+          <span
+            className={`badge ${
+              eventType === "feature.created"
+                ? "badge-success"
+                : eventType === "feature.deleted"
+                ? "badge-danger"
+                : "badge-info"
+            }`}
+          >
+            {formatEventType(eventType)}
+          </span>
+        </td>
+        <td>
+          <span className="py-1 d-block" title={userEmail}>
+            {userDisplay}
+          </span>
+        </td>
+        <td>
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              setShowDetails(!showDetails);
+            }}
+          >
+            <div className="d-flex align-items-center py-1">
+              <span className="mb-0">{changesSummary}</span>
+              {showDetails ? (
+                <FaAngleUp className="ml-2" />
+              ) : (
+                <FaAngleDown className="ml-2" />
+              )}
+            </div>
+          </a>
+          {showDetails && (
+            <div className="mt-2">
+              {canShowDiff ? (
+                <JsonDiff
+                  defaultVal={JSON.stringify(previousState, null, 2)}
+                  value={JSON.stringify(currentState, null, 2)}
+                  fullStyle={{
+                    maxHeight: 400,
+                    overflowY: "auto",
+                    maxWidth: "100%",
+                  }}
+                />
+              ) : (
+                <Code
+                  language="json"
+                  filename={
+                    eventType === "feature.created"
+                      ? "New Feature"
+                      : eventType === "feature.deleted"
+                      ? "Deleted Feature"
+                      : "Feature State"
+                  }
+                  code={JSON.stringify(currentState || previousState, null, 2)}
+                  expandable={false}
+                />
+              )}
+            </div>
+          )}
+        </td>
+        <td>
+          <span className="tr-hover small py-1">
+            <Link href={`/events/${event.id}`}>Details</Link>
+          </span>
+        </td>
+      </tr>
+    </>
+  );
+};

--- a/packages/front-end/components/Features/FeatureHistory/utils.ts
+++ b/packages/front-end/components/Features/FeatureHistory/utils.ts
@@ -1,0 +1,77 @@
+export const FEATURE_EVENT_TYPES = [
+  "feature.created",
+  "feature.updated",
+  "feature.deleted",
+] as const;
+
+export type FeatureEventType = typeof FEATURE_EVENT_TYPES[number];
+
+interface FilterParams {
+  currentPage: number;
+  perPage: number;
+  fromDate: Date | null;
+  toDate: Date | null;
+  sortOrder: "asc" | "desc";
+}
+
+export function buildFeatureHistoryFilterParams({
+  currentPage,
+  perPage,
+  fromDate,
+  toDate,
+  sortOrder,
+}: FilterParams): string {
+  return new URLSearchParams({
+    page: currentPage.toString(),
+    perPage: perPage.toString(),
+    from: fromDate ? fromDate.toISOString() : "",
+    to: toDate ? toDate.toISOString() : "",
+    type: JSON.stringify([...FEATURE_EVENT_TYPES]),
+    sortOrder,
+  }).toString();
+}
+
+export function getFeatureChangesSummary(
+  eventType: string,
+  previousAttributes: Record<string, unknown> | undefined
+): string {
+  if (eventType === "feature.created") {
+    return "Feature created";
+  }
+
+  if (eventType === "feature.deleted") {
+    return "Feature deleted";
+  }
+
+  if (eventType === "feature.updated") {
+    if (!previousAttributes || Object.keys(previousAttributes).length === 0) {
+      return "Feature updated";
+    }
+
+    const changedFields = Object.keys(previousAttributes);
+    const maxFieldsToShow = 3;
+
+    if (changedFields.length <= maxFieldsToShow) {
+      return `Changed: ${changedFields.join(", ")}`;
+    }
+
+    const shownFields = changedFields.slice(0, maxFieldsToShow);
+    const remainingCount = changedFields.length - maxFieldsToShow;
+    return `Changed: ${shownFields.join(", ")}, +${remainingCount} more`;
+  }
+
+  return eventType;
+}
+
+export function formatEventType(eventType: string): string {
+  switch (eventType) {
+    case "feature.created":
+      return "Created";
+    case "feature.updated":
+      return "Updated";
+    case "feature.deleted":
+      return "Deleted";
+    default:
+      return eventType;
+  }
+}

--- a/packages/front-end/pages/features/history.tsx
+++ b/packages/front-end/pages/features/history.tsx
@@ -1,0 +1,5 @@
+import { FeatureHistoryPage } from "@/components/Features/FeatureHistory/FeatureHistoryPage";
+
+export default function FeaturesHistoryPage() {
+  return <FeatureHistoryPage />;
+}

--- a/packages/front-end/pages/features/index.tsx
+++ b/packages/front-end/pages/features/index.tsx
@@ -574,12 +574,17 @@ export default function FeaturesPage() {
         <div className="col">
           <h1>Features</h1>
         </div>
-        {features.length > 0 &&
-          permissionsUtil.canViewFeatureModal(project) &&
-          canCreateFeatures && (
-            <div className="col-auto">
+        <div className="col-auto d-flex align-items-center">
+          {permissionsUtil.canViewAuditLogs() && (
+            <Link href="/features/history" className="btn btn-outline-primary">
+              View History
+            </Link>
+          )}
+          {features.length > 0 &&
+            permissionsUtil.canViewFeatureModal(project) &&
+            canCreateFeatures && (
               <button
-                className="btn btn-primary float-right"
+                className="btn btn-primary ml-2"
                 onClick={() => {
                   setModalOpen(true);
                   track("Viewed Feature Modal", {
@@ -593,8 +598,8 @@ export default function FeaturesPage() {
                 </span>
                 Add Feature
               </button>
-            </div>
-          )}
+            )}
+        </div>
       </div>
       <p>
         Features enable you to change your app&apos;s behavior from within the

--- a/packages/front-end/test/components/Features/featureHistory.test.ts
+++ b/packages/front-end/test/components/Features/featureHistory.test.ts
@@ -1,0 +1,163 @@
+import {
+  buildFeatureHistoryFilterParams,
+  getFeatureChangesSummary,
+  formatEventType,
+  FEATURE_EVENT_TYPES,
+} from "@/components/Features/FeatureHistory/utils";
+
+describe("Feature History Utils", () => {
+  describe("FEATURE_EVENT_TYPES", () => {
+    it("should contain the correct feature event types", () => {
+      expect(FEATURE_EVENT_TYPES).toEqual([
+        "feature.created",
+        "feature.updated",
+        "feature.deleted",
+      ]);
+    });
+  });
+
+  describe("buildFeatureHistoryFilterParams", () => {
+    it("should build params with pagination", () => {
+      const params = buildFeatureHistoryFilterParams({
+        currentPage: 2,
+        perPage: 30,
+        fromDate: null,
+        toDate: null,
+        sortOrder: "desc",
+      });
+
+      const parsed = new URLSearchParams(params);
+      expect(parsed.get("page")).toBe("2");
+      expect(parsed.get("perPage")).toBe("30");
+      expect(parsed.get("sortOrder")).toBe("desc");
+      expect(parsed.get("type")).toBe(JSON.stringify(FEATURE_EVENT_TYPES));
+    });
+
+    it("should include fromDate when provided", () => {
+      const fromDate = new Date("2024-01-15T00:00:00.000Z");
+      const params = buildFeatureHistoryFilterParams({
+        currentPage: 1,
+        perPage: 30,
+        fromDate,
+        toDate: null,
+        sortOrder: "desc",
+      });
+
+      const parsed = new URLSearchParams(params);
+      expect(parsed.get("from")).toBe(fromDate.toISOString());
+    });
+
+    it("should include toDate when provided", () => {
+      const toDate = new Date("2024-01-20T23:59:59.000Z");
+      const params = buildFeatureHistoryFilterParams({
+        currentPage: 1,
+        perPage: 30,
+        fromDate: null,
+        toDate,
+        sortOrder: "desc",
+      });
+
+      const parsed = new URLSearchParams(params);
+      expect(parsed.get("to")).toBe(toDate.toISOString());
+    });
+
+    it("should include both dates when provided", () => {
+      const fromDate = new Date("2024-01-15T00:00:00.000Z");
+      const toDate = new Date("2024-01-20T23:59:59.000Z");
+      const params = buildFeatureHistoryFilterParams({
+        currentPage: 1,
+        perPage: 30,
+        fromDate,
+        toDate,
+        sortOrder: "asc",
+      });
+
+      const parsed = new URLSearchParams(params);
+      expect(parsed.get("from")).toBe(fromDate.toISOString());
+      expect(parsed.get("to")).toBe(toDate.toISOString());
+      expect(parsed.get("sortOrder")).toBe("asc");
+    });
+
+    it("should have empty from/to when dates are null", () => {
+      const params = buildFeatureHistoryFilterParams({
+        currentPage: 1,
+        perPage: 30,
+        fromDate: null,
+        toDate: null,
+        sortOrder: "desc",
+      });
+
+      const parsed = new URLSearchParams(params);
+      expect(parsed.get("from")).toBe("");
+      expect(parsed.get("to")).toBe("");
+    });
+  });
+
+  describe("getFeatureChangesSummary", () => {
+    it("should return 'Feature created' for feature.created events", () => {
+      const summary = getFeatureChangesSummary("feature.created", undefined);
+      expect(summary).toBe("Feature created");
+    });
+
+    it("should return 'Feature deleted' for feature.deleted events", () => {
+      const summary = getFeatureChangesSummary("feature.deleted", undefined);
+      expect(summary).toBe("Feature deleted");
+    });
+
+    it("should return changed fields for feature.updated events", () => {
+      const previousAttributes = {
+        defaultValue: "false",
+        description: "Old description",
+      };
+      const summary = getFeatureChangesSummary(
+        "feature.updated",
+        previousAttributes
+      );
+      expect(summary).toBe("Changed: defaultValue, description");
+    });
+
+    it("should return 'Feature updated' when no previous_attributes for update", () => {
+      const summary = getFeatureChangesSummary("feature.updated", undefined);
+      expect(summary).toBe("Feature updated");
+    });
+
+    it("should return 'Feature updated' when previous_attributes is empty for update", () => {
+      const summary = getFeatureChangesSummary("feature.updated", {});
+      expect(summary).toBe("Feature updated");
+    });
+
+    it("should truncate long lists of changed fields", () => {
+      const previousAttributes = {
+        field1: "a",
+        field2: "b",
+        field3: "c",
+        field4: "d",
+        field5: "e",
+        field6: "f",
+      };
+      const summary = getFeatureChangesSummary(
+        "feature.updated",
+        previousAttributes
+      );
+      expect(summary).toBe("Changed: field1, field2, field3, +3 more");
+    });
+  });
+
+  describe("formatEventType", () => {
+    it("should format feature.created as Created", () => {
+      expect(formatEventType("feature.created")).toBe("Created");
+    });
+
+    it("should format feature.updated as Updated", () => {
+      expect(formatEventType("feature.updated")).toBe("Updated");
+    });
+
+    it("should format feature.deleted as Deleted", () => {
+      expect(formatEventType("feature.deleted")).toBe("Deleted");
+    });
+
+    it("should return the event type for unknown types", () => {
+      expect(formatEventType("unknown.type")).toBe("unknown.type");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Create new page at `/features/history` to view all feature flag changes within a date range
- Add date range filters (from/to) for filtering events by time period
- Display table with Date/Time, Feature (linked), Event Type, User, and Changes columns
- Show JsonDiff for update events to visualize before/after state changes
- Add pagination and configurable page size (10/20/30/50/100)
- Add "View History" button on Features list page (visible to users with audit log permissions)
- Reuse existing `/events` API endpoint filtered to feature event types

## TODO list
- [x] Write unit tests for utility functions (TDD)
- [x] Create page route at `/features/history`
- [x] Create FeatureHistoryPage component with date filters and pagination
- [x] Create FeatureHistoryRow component with expandable diff view
- [x] Add "View History" link to Features list page
- [x] Run tests and type check