### PR TITLE
Add manual trigger to coderefs workflow

### DIFF
--- a/.github/workflows/coderefs.yml
+++ b/.github/workflows/coderefs.yml
@@ -1,6 +1,5 @@
 name: Find feature flag code references
 on:
-  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/coderefs.yml
+++ b/.github/workflows/coderefs.yml
@@ -1,5 +1,6 @@
 name: Find feature flag code references
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+GrowthBook is a Yarn workspaces monorepo. Core app code lives in `packages/front-end` (Next.js UI) and `packages/back-end` (Express API). Shared TypeScript utilities sit in `packages/shared`, enterprise code in `packages/enterprise`, while `packages/sdk-js` and `packages/sdk-react` house the public SDKs. The Python stats engine lives in `packages/stats` (Poetry-managed), and the documentation site resides in `docs`. Config templates (`.env.example`) ship with each package for local overrides.
+
+## Build, Test, and Development Commands
+
+- `yarn setup` installs workspace deps, builds shared artifacts, and primes the stats virtualenv.
+- `yarn dev` runs front-end and back-end together with hot reload (`http://localhost:3000`, API on `:3100`).
+- `yarn build` executes dependency builds then compiles the app; use before releasing.
+- `yarn test`, `yarn type-check`, `yarn lint` cover monorepo Jest, TypeScript, and ESLint checks.
+- `yarn workspace stats test|lint|build` targets the Python analytics engine pipelines.
+- Docs preview: `cd docs && yarn dev` starts Docusaurus at `http://localhost:3200`.
+
+## Coding Style & Naming Conventions
+
+TypeScript and React code follow ESLint + Prettier defaults (2-space indent, semicolons, single quotes). Use `PascalCase` for components, `camelCase` for functions/variables, and `SCREAMING_SNAKE_CASE` for env keys. Prefer configured module aliases (`@back-end/...`, `@/components/...`) over deep relative imports. Python stats code is formatted with Black and linted via Flake8; keep identifiers snake_case.
+
+## Testing Guidelines
+
+Jest drives the Node packages; colocate specs in `test/` directories using `.test.ts` files. Run `yarn test` before pushing, or narrow scope with `yarn workspace <pkg> test`. The stats engine relies on PyTest through `yarn workspace stats test`. Add regression coverage alongside feature work and refresh mocked fixtures when APIs or schemas evolve.
+
+## Commit & Pull Request Guidelines
+
+Commits typically follow `MT-1234: short imperative summary`; include a ticket key when available and keep each commit focused. Ensure lint, type checks, and relevant tests succeed before pushing. Pull requests should link issues, explain intent, and flag rollout or config steps. Add screenshots or API samples when UI or behavior changes, and wait for passing CI before requesting review.
+
+## Security & Configuration Tips
+
+Never commit secrets; copy `.env.example` to `.env.local` within the package you touch and populate locally. Use Docker (`docker-compose up` or the documented `docker run` command) to provision MongoDB during development. Consult `SECURITY.md` for vulnerability reporting expectations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing Guide
 
-Interested in making GrowthBook better? So are we! This guide should help get you setup with a local development environment so you can make changes, create PRs, and get your code merged.
-
-If you just want to contribute a client library in a new language and not make changes to the app itself, you can skip the instructions here and view https://docs.growthbook.io/lib/build-your-own instead.
+Use the following steps to setup local development
 
 ## Requirements
 
@@ -16,35 +14,18 @@ If you just want to contribute a client library in a new language and not make c
   - [pandas](https://pandas.pydata.org/docs/getting_started/install.html)
 - [Docker](https://docs.docker.com/engine/install/) (for running MongoDB locally)
 
-### Windows users
-
-One sure shot way to run GrowthBook on Windows is through installing [Windows Subsystem for Linux (WSL)](https://docs.microsoft.com/en-us/windows/wsl/setup/environment#set-up-your-linux-user-info). These are some of the steps to follow, also outlined in the link above:
-
-1. Search for your terminal app in the windows search bar
-2. Select the option to "Run as administrator"
-3. Now, on the terminal, run `wsl --install`
-4. After the installation is complete, restart your computer
-5. Set up your Linux username and password
-6. Run `sudo apt update && sudo apt upgrade` (for Ubuntu or Desbian) to update and upgrade packages
-
-Now you have the basic Linux system set up, and can follow along with all the other steps.
-
-It's **strongly recommended** that if you are using WSL on Windows that you run the project from your `/home/:user` directory rather than a `/mnt/` directory: the `/mnt` directory has poor performance, and the file watcher for nodemon will not work, requiring you to manually stop and re-run the `yarn dev` command.
-
 ## Getting started
 
-1. Fork the project
-2. Clone your forked project by running `git clone git@github.com:{ YOUR_USERNAME }/growthbook.git`
-   - Can also use `git clone` and list the HTTPS URL of the repo afterwards
-3. Run `cd growthbook`
-4. Run `yarn` to install dependencies
-5. Install [poetry](https://python-poetry.org/docs/)
+1. Clone this repo locally
+2. Run `cd growthbook`
+3. Run `yarn` to install dependencies
+4. Install [poetry](https://python-poetry.org/docs/)
    - Run `curl -sSL https://install.python-poetry.org | python3 -`
    - Close and reopen your terminal
    - Run `poetry --version` to confirm a successful install
    - If unsuccessful add the Poetry path (ex. `$HOME/.poetry/bin`) to your global path (ex. `/etc/profile`, `/etc/environment`, `~/.bashrc`, `~/.zshrc`)
-6. Run `yarn setup` to do the initial build
-7. If you have Docker installed, start MongoDB in Docker:
+5. Run `yarn setup` to do the initial build
+6. If you have Docker installed, start MongoDB in Docker:
 
 ```sh
 docker run -d -p 27017:27017 --name mongo \

--- a/README.md
+++ b/README.md
@@ -6,24 +6,21 @@
     <a href="https://slack.growthbook.io?ref=readme-badge"><img src="https://img.shields.io/badge/slack-join-E01E5A?logo=slack" alt="Join us on Slack" height="22"/></a>
 </p>
 
-Get up and running in 1 minute with:
+## Development
 
-```sh
-git clone https://github.com/growthbook/growthbook.git
-cd growthbook
-docker-compose up -d
-```
+See the [Contributing Guide](https://github.com/sp0n-7/growthbook/blob/main/CONTRIBUTING.md)
 
-Then visit http://localhost:3000
+### Requirements
 
-[![GrowthBook Screenshot](/features-screenshot.png)](https://www.growthbook.io)
-
-## Our Philosophy
-
-The top 1% of companies spend thousands of hours building their own feature flagging and A/B testing platforms in-house.
-The other 99% are left paying for expensive 3rd party SaaS tools or hacking together unmaintained open source libraries.
-
-We want to give all companies the flexibility and power of a fully-featured in-house platform without needing to build it themselves.
+- MacOS or Linux (Windows may work too, but we haven't tested it)
+- [NodeJS](https://nodejs.org/en/download/package-manager/) 18.x or above
+  - Check version by running `node -v` on terminal
+- [Yarn](https://classic.yarnpkg.com/en/docs/install)
+- [Python](https://www.python.org/downloads/) 3.8+ (for the stats engine)
+  - [scipy](https://scipy.org/install/)
+  - [numpy](https://numpy.org/install/)
+  - [pandas](https://pandas.pydata.org/docs/getting_started/install.html)
+- [Docker](https://docs.docker.com/engine/install/) (for running MongoDB locally)
 
 ## Major Features
 
@@ -36,26 +33,6 @@ We want to give all companies the flexibility and power of a fully-featured in-h
 - 📝 Document everything with screenshots and GitHub Flavored Markdown throughout
 - 🔔 Webhooks and a REST API for building integrations
 
-## Try GrowthBook
-
-### Managed Cloud Hosting
-
-Create a free [GrowthBook Cloud](https://app.growthbook.io) account to get started.
-
-### Open Source
-
-The included [docker-compose.yml](https://github.com/growthbook/growthbook/blob/main/docker-compose.yml) file contains the GrowthBook App and a MongoDB instance (for storing cached experiment results and metadata):
-
-```sh
-git clone https://github.com/growthbook/growthbook.git
-cd growthbook
-docker-compose up -d
-```
-
-Then visit http://localhost:3000 to view the app.
-
-Check out the full [Self-Hosting Instructions](https://docs.growthbook.io/self-host) for more details.
-
 ## Documentation and Support
 
 View the [GrowthBook Docs](https://docs.growthbook.io) for info on how to configure and use the platform.
@@ -65,14 +42,6 @@ Join [our Slack community](https://slack.growthbook.io?ref=readme-support) if yo
 Or email us at [hello@growthbook.io](mailto:hello@growthbook.io) if Slack isn't your thing.
 
 We're here to help - and to make GrowthBook even better!
-
-## Contributors
-
-We ❤️ all contributions, big and small!
-
-Read [CONTRIBUTING.md](/CONTRIBUTING.md) for how to setup your local development environment.
-
-If you want to, you can reach out via [Slack](https://slack.growthbook.io?ref=readme-contributing) or [email](mailto:hello@growthbook.io) and we'll set up a pair programming session to get you started.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the code references workflow
- Enables manual triggering for testing secrets and debugging

## Test plan
- [x] Manually triggered workflow from branch - passed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)