### PR TITLE
Add front-end vs back-end experiment warning to targeting modal

### DIFF
--- a/packages/front-end/components/Experiment/EditTargetingModal.tsx
+++ b/packages/front-end/components/Experiment/EditTargetingModal.tsx
@@ -459,6 +459,12 @@ function TargetingForm({
 
   return (
     <div className="px-2 pt-2">
+      <div className="alert alert-warning">
+        ⚠️ These settings are only relevant for front-end experiments run via
+        feature flags in GrowthBook. This will not influence back-end
+        experiments.
+      </div>
+
       {safeToEdit && (
         <>
           <Field

--- a/packages/front-end/components/Experiment/NewExperimentForm.tsx
+++ b/packages/front-end/components/Experiment/NewExperimentForm.tsx
@@ -251,6 +251,11 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
       throw new Error("Experiment Name must not be empty");
     }
 
+    if (isNewExperiment && !value.hashAttribute) {
+      setStep(1);
+      throw new Error("Please select an attribute to assign variations");
+    }
+
     // TODO: more validation?
     const data = { ...value };
 
@@ -486,6 +491,7 @@ const NewExperimentForm: FC<NewExperimentFormProps> = ({
                   containerClassName="flex-1"
                   label="Assign variation based on attribute"
                   labelClassName="font-weight-bold"
+                  required
                   options={attributeSchema
                     .filter((s) => !hasHashAttributes || s.hashAttribute)
                     .map((s) => ({ label: s.property, value: s.property }))}


### PR DESCRIPTION
### Features and Changes

This PR bundles two changes to the experiment creation/editing flow:

**1. Front-end vs back-end experiment warning (EditTargetingModal)**

Adds a warning banner at the top of the targeting form to clarify that targeting settings only apply to front-end experiments run via GrowthBook feature flags, and do not influence back-end experiments.

- New alert banner rendered above the targeting form fields
- Message: "These settings are only relevant for front-end experiments run via feature flags in GrowthBook. This will not influence back-end experiments."

<img width="835" height="907" alt="Edit Targeting modal with front-end vs back-end warning banner" src="https://github.com/user-attachments/assets/ed725410-b564-476a-961e-5f32c2784687" />

**2. Required "Assign variation based on attribute" (NewExperimentForm)**

Makes the hash attribute selection mandatory in the New Experiment modal. Previously, leaving this field empty caused a silent fallback to the literal string `"id"` at SDK-payload time — if `id` wasn't a real attribute on the user context, users never got bucketed.

- `required` marker added to the SelectField
- Explicit validation in `onSubmit` that jumps back to the Variation Assignment step and surfaces an error if empty
- Guarded on `isNewExperiment` so the import flow (which doesn't render the field) isn't affected

<img width="835" height="907" alt="New Experiment modal showing required validation on Assign variation based on attribute" src="https://github.com/user-attachments/assets/a75b0dfd-ccff-4378-afe1-d8c5012ceb67" />

### Dependencies

None

### Testing

1. Open any existing experiment → click "Edit Targeting" → verify the warning banner appears at the top.
2. From the experiments list → click "Add Experiment" → "New Experiment" → navigate to the Variation Assignment page → try submitting without selecting an attribute → confirm the required error blocks submission and the modal returns to that step.
3. Regression: duplicate an existing experiment → confirm the hashAttribute is pre-populated and submission succeeds.
4. Regression: trigger the import flow → confirm the hashAttribute select isn't shown and submission still works.