### PR TITLE
Raise Node heap limit for yarn build to fix OOM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN yarn install --frozen-lockfile --ignore-optional
 RUN yarn postinstall
 # Build the app and do a clean install with only production dependencies
 COPY packages ./packages
+ENV NODE_OPTIONS=--max-old-space-size=4096
 RUN \
   yarn build \
   && rm -rf node_modules \


### PR DESCRIPTION
## Summary
The `yarn build` step in the `nodebuild` stage hits V8's default ~2 GB old-gen heap limit and aborts with `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` (exit 134). The Next.js front-end build (~75 static pages, several 1+ MB bundles) is what tips it over.

This sets `NODE_OPTIONS=--max-old-space-size=4096` for the build step so Node can use the memory the build host already has available.

## Notes
- `ENV` only applies inside the `nodebuild` build stage. The runtime image is built from a fresh `FROM`, so the variable does not leak into the final image.
- The subsequent production `yarn install` in the same stage is unaffected (a higher cap is harmless).

## Test plan
- [ ] Trigger the `main-growthbook` Cloud Build (push to `main`) and confirm `yarn build` completes without OOM.